### PR TITLE
Move file I/O to service

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,13 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:file_picker/file_picker.dart';
-import 'package:path_provider/path_provider.dart';
-import 'dart:convert';
 import 'dart:io';
-import 'package:intl/intl.dart';
 import 'package:open_filex/open_filex.dart';
-import 'package:image_picker/image_picker.dart';
+import '../services/file_service.dart';
 import '../providers/app_state_provider.dart';
 import '../services/database_service.dart';
 import '../models/app_settings.dart';
@@ -889,32 +885,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       setState(() => _isProcessing = true);
 
-      final appState = context.read<AppStateProvider>();
       final databaseService = DatabaseService.instance;
-
-      // Export all data
       final allData = await databaseService.exportAllData();
 
-      // Get downloads directory
-      final directory = await getApplicationDocumentsDirectory();
-      final fileName = 'rufko_backup_${DateFormat('yyyy-MM-dd_HH-mm').format(DateTime.now())}.json';
-      final file = File('${directory.path}/$fileName');
-
-      // Write JSON data
-      await file.writeAsString(
-        const JsonEncoder.withIndent('  ').convert(allData),
-      );
+      final filePath =
+          await FileService.instance.saveExportedData(allData);
 
       if (mounted) {
+        final fileName = filePath.split('/').last;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Data exported to: $fileName'),
             backgroundColor: Colors.green,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
             action: SnackBarAction(
               label: 'Open',
-              onPressed: () => OpenFilex.open(file.path),
+              onPressed: () => OpenFilex.open(filePath),
             ),
           ),
         );
@@ -926,7 +914,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             content: Text('Export failed: $e'),
             backgroundColor: Colors.red,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
         );
       }
@@ -937,14 +926,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _importData() async {
     try {
-      FilePickerResult? result = await FilePicker.platform.pickFiles(
-        type: FileType.custom,
-        allowedExtensions: ['json'],
-      );
+      final data = await FileService.instance.pickAndReadBackupFile();
 
-      if (result != null && result.files.single.path != null) {
-        final file = File(result.files.single.path!);
-
+      if (data.isNotEmpty) {
         // Show confirmation dialog
         final confirmed = await showDialog<bool>(
           context: context,
@@ -981,9 +965,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         if (confirmed == true) {
           setState(() => _isProcessing = true);
-
-          final jsonString = await file.readAsString();
-          final data = jsonDecode(jsonString) as Map<String, dynamic>;
 
           final databaseService = DatabaseService.instance;
           await databaseService.importAllData(data);
@@ -1370,31 +1351,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _selectCompanyLogo(StateSetter setDialogState, AppSettings settings, AppStateProvider appState) async {
     try {
-      final ImagePicker picker = ImagePicker();
-      final XFile? image = await picker.pickImage(
-        source: ImageSource.gallery,
-        maxWidth: 512,
-        maxHeight: 512,
-        imageQuality: 85,
-      );
+      final newPath = await FileService.instance.pickAndSaveCompanyLogo();
 
-      if (image != null) {
-        // Get the app documents directory
-        final directory = await getApplicationDocumentsDirectory();
-        final logoDir = Directory('${directory.path}/company_logos');
-
-        // Create directory if it doesn't exist
-        if (!await logoDir.exists()) {
-          await logoDir.create(recursive: true);
-        }
-
-        // Copy image to app directory with unique name
-        final fileName = 'company_logo_${DateTime.now().millisecondsSinceEpoch}.${image.path.split('.').last}';
-        final newPath = '${logoDir.path}/$fileName';
-
-        await File(image.path).copy(newPath);
-
-        // Update settings
+      if (newPath != null) {
         settings.updateCompanyLogo(newPath);
         appState.updateAppSettings(settings);
 
@@ -1405,7 +1364,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             content: const Text('Company logo updated!'),
             backgroundColor: Colors.green,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
         );
       }

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+
+class FileService {
+  FileService._internal();
+  static final FileService instance = FileService._internal();
+
+  /// Pick an image from gallery and store it inside the application
+  /// documents directory under `company_logos`. Returns the new
+  /// file path or `null` if no image was selected.
+  Future<String?> pickAndSaveCompanyLogo({
+    XFile? image,
+    Directory? baseDirectory,
+  }) async {
+    final picker = ImagePicker();
+    final XFile? selectedImage =
+        image ?? await picker.pickImage(source: ImageSource.gallery, maxWidth: 512, maxHeight: 512, imageQuality: 85);
+
+    if (selectedImage == null) return null;
+
+    final directory = baseDirectory ?? await getApplicationDocumentsDirectory();
+    final logoDir = Directory('${directory.path}/company_logos');
+    if (!await logoDir.exists()) {
+      await logoDir.create(recursive: true);
+    }
+    final extension = selectedImage.path.split('.').last;
+    final fileName =
+        'company_logo_${DateTime.now().millisecondsSinceEpoch}.$extension';
+    final newPath = '${logoDir.path}/$fileName';
+    await File(selectedImage.path).copy(newPath);
+    return newPath;
+  }
+
+  /// Save exported [data] to a json file in the application documents
+  /// directory. Returns the written file path.
+  Future<String> saveExportedData(
+    Map<String, dynamic> data, {
+    Directory? baseDirectory,
+  }) async {
+    final directory = baseDirectory ?? await getApplicationDocumentsDirectory();
+    final fileName =
+        'rufko_backup_${DateFormat('yyyy-MM-dd_HH-mm').format(DateTime.now())}.json';
+    final file = File('${directory.path}/$fileName');
+    await file.writeAsString(const JsonEncoder.withIndent('  ').convert(data));
+    return file.path;
+  }
+
+  /// Pick a backup file (json) and return its parsed contents as a map.
+  Future<Map<String, dynamic>> pickAndReadBackupFile({String? filePath}) async {
+    String? path = filePath;
+    if (path == null) {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+      if (result == null || result.files.single.path == null) {
+        throw Exception('No file selected');
+      }
+      path = result.files.single.path!;
+    }
+    final file = File(path);
+    final jsonString = await file.readAsString();
+    return jsonDecode(jsonString) as Map<String, dynamic>;
+  }
+}

--- a/test/services/file_service_test.dart
+++ b/test/services/file_service_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:rufko/services/file_service.dart';
+
+void main() {
+  test('saveExportedData writes json file', () async {
+    final dir = await Directory.systemTemp.createTemp('rufko_test_export');
+    final filePath =
+        await FileService.instance.saveExportedData({'a': 1}, baseDirectory: dir);
+    final file = File(filePath);
+    expect(await file.exists(), isTrue);
+    final contents = await file.readAsString();
+    expect(contents.contains('"a"'), isTrue);
+  });
+
+  test('pickAndSaveCompanyLogo copies image to directory', () async {
+    final sourceDir = await Directory.systemTemp.createTemp('rufko_source');
+    final src = File('${sourceDir.path}/logo.jpg');
+    await src.writeAsBytes(List.filled(5, 1));
+
+    final destDir = await Directory.systemTemp.createTemp('rufko_dest');
+    final newPath = await FileService.instance.pickAndSaveCompanyLogo(
+      image: XFile(src.path),
+      baseDirectory: destDir,
+    );
+
+    expect(newPath, isNotNull);
+    expect(await File(newPath!).exists(), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `FileService` to manage picking and saving files
- refactor `SettingsScreen` to use `FileService`
- add unit tests for new service logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427899c3c8832cb5f1033a542793a4