### PR TITLE
Add provider unit tests and dashboard widgets

### DIFF
--- a/lib/providers/customer_provider.dart
+++ b/lib/providers/customer_provider.dart
@@ -3,8 +3,11 @@ import '../models/customer.dart';
 import '../services/database_service.dart';
 
 class CustomerProvider extends ChangeNotifier {
-  final DatabaseService _db = DatabaseService.instance;
+  final DatabaseService _db;
   List<Customer> _customers = [];
+
+  CustomerProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
 
   List<Customer> get customers => _customers;
 

--- a/lib/providers/product_provider.dart
+++ b/lib/providers/product_provider.dart
@@ -3,8 +3,11 @@ import '../models/product.dart';
 import '../services/database_service.dart';
 
 class ProductProvider extends ChangeNotifier {
-  final DatabaseService _db = DatabaseService.instance;
+  final DatabaseService _db;
   List<Product> _products = [];
+
+  ProductProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
 
   List<Product> get products => _products;
 

--- a/lib/providers/quote_provider.dart
+++ b/lib/providers/quote_provider.dart
@@ -5,9 +5,12 @@ import '../services/database_service.dart';
 import '../services/pdf_service.dart';
 
 class QuoteProvider extends ChangeNotifier {
-  final DatabaseService _db = DatabaseService.instance;
+  final DatabaseService _db;
   final PdfService _pdfService = PdfService();
   List<SimplifiedMultiLevelQuote> _quotes = [];
+
+  QuoteProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
 
   List<SimplifiedMultiLevelQuote> get quotes => _quotes;
 

--- a/lib/providers/template_provider.dart
+++ b/lib/providers/template_provider.dart
@@ -6,11 +6,14 @@ import '../models/template_category.dart';
 import '../services/database_service.dart';
 
 class TemplateProvider extends ChangeNotifier {
-  final DatabaseService _db = DatabaseService.instance;
+  final DatabaseService _db;
   List<PDFTemplate> _pdfTemplates = [];
   List<MessageTemplate> _messageTemplates = [];
   List<EmailTemplate> _emailTemplates = [];
   List<TemplateCategory> _categories = [];
+
+  TemplateProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
 
   List<PDFTemplate> get pdfTemplates => _pdfTemplates;
   List<MessageTemplate> get messageTemplates => _messageTemplates;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0 # From your output: (6.0.0 available for lints, implying flutter_lints)
+  mocktail: ^1.0.0
 
   # Hive code generation
   hive_generator: ^2.0.1

--- a/test/customers_screen_test.dart
+++ b/test/customers_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:rufko/providers/app_state_provider.dart';
+import 'package:rufko/screens/customers_screen.dart';
+
+void main() {
+  testWidgets('Customers screen has title', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppStateProvider>(
+        create: (_) => AppStateProvider(),
+        child: const MaterialApp(home: CustomersScreen()),
+      ),
+    );
+
+    expect(find.text('Customers'), findsOneWidget);
+  });
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rufko/main.dart';
+
+void main() {
+  testWidgets('Home screen shows navigation items', (WidgetTester tester) async {
+    await tester.pumpWidget(const RufkoApp());
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Customers'), findsOneWidget);
+  });
+}

--- a/test/providers/customer_provider_test.dart
+++ b/test/providers/customer_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rufko/providers/customer_provider.dart';
+import 'package:rufko/models/customer.dart';
+import 'package:rufko/services/database_service.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockDatabaseService db;
+  late CustomerProvider provider;
+
+  setUp(() {
+    db = MockDatabaseService();
+    provider = CustomerProvider(database: db);
+  });
+
+  test('loadCustomers populates list', () async {
+    final customer = Customer(name: 'Test');
+    when(() => db.getAllCustomers()).thenAnswer((_) async => [customer]);
+
+    await provider.loadCustomers();
+
+    expect(provider.customers, [customer]);
+  });
+
+  test('addCustomer adds item to list', () async {
+    final customer = Customer(name: 'Test');
+    when(() => db.saveCustomer(customer)).thenAnswer((_) async {});
+
+    await provider.addCustomer(customer);
+
+    expect(provider.customers.contains(customer), isTrue);
+    verify(() => db.saveCustomer(customer)).called(1);
+  });
+
+  test('updateCustomer updates existing item', () async {
+    final customer = Customer(name: 'Test');
+    provider.customers.add(customer);
+
+    final updated = Customer(id: customer.id, name: 'Updated');
+    when(() => db.saveCustomer(updated)).thenAnswer((_) async {});
+
+    await provider.updateCustomer(updated);
+
+    expect(provider.customers.first.name, 'Updated');
+  });
+
+  test('deleteCustomer removes item from list', () async {
+    final customer = Customer(name: 'Test');
+    provider.customers.add(customer);
+    when(() => db.deleteCustomer(customer.id)).thenAnswer((_) async {});
+
+    await provider.deleteCustomer(customer.id);
+
+    expect(provider.customers, isEmpty);
+  });
+}

--- a/test/providers/product_provider_test.dart
+++ b/test/providers/product_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rufko/providers/product_provider.dart';
+import 'package:rufko/models/product.dart';
+import 'package:rufko/services/database_service.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockDatabaseService db;
+  late ProductProvider provider;
+
+  setUp(() {
+    db = MockDatabaseService();
+    provider = ProductProvider(database: db);
+  });
+
+  test('loadProducts populates list', () async {
+    final product = Product(name: 'Prod', unitPrice: 10);
+    when(() => db.getAllProducts()).thenAnswer((_) async => [product]);
+
+    await provider.loadProducts();
+
+    expect(provider.products, [product]);
+  });
+
+  test('addProduct adds item to list', () async {
+    final product = Product(name: 'Prod', unitPrice: 10);
+    when(() => db.saveProduct(product)).thenAnswer((_) async {});
+
+    await provider.addProduct(product);
+
+    expect(provider.products.contains(product), isTrue);
+    verify(() => db.saveProduct(product)).called(1);
+  });
+
+  test('updateProduct updates existing item', () async {
+    final product = Product(name: 'Prod', unitPrice: 10);
+    provider.products.add(product);
+
+    final updated = Product(id: product.id, name: 'New', unitPrice: 20);
+    when(() => db.saveProduct(updated)).thenAnswer((_) async {});
+
+    await provider.updateProduct(updated);
+
+    expect(provider.products.first.name, 'New');
+  });
+
+  test('deleteProduct removes item from list', () async {
+    final product = Product(name: 'Prod', unitPrice: 10);
+    provider.products.add(product);
+    when(() => db.deleteProduct(product.id)).thenAnswer((_) async {});
+
+    await provider.deleteProduct(product.id);
+
+    expect(provider.products, isEmpty);
+  });
+}

--- a/test/providers/quote_provider_test.dart
+++ b/test/providers/quote_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/models/simplified_quote.dart';
+import 'package:rufko/services/database_service.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockDatabaseService db;
+  late QuoteProvider provider;
+
+  setUp(() {
+    db = MockDatabaseService();
+    provider = QuoteProvider(database: db);
+  });
+
+  test('loadQuotes populates list', () async {
+    final quote = SimplifiedMultiLevelQuote(customerId: '1');
+    when(() => db.getAllSimplifiedMultiLevelQuotes()).thenAnswer((_) async => [quote]);
+
+    await provider.loadQuotes();
+
+    expect(provider.quotes, [quote]);
+  });
+
+  test('addQuote adds item to list', () async {
+    final quote = SimplifiedMultiLevelQuote(customerId: '1');
+    when(() => db.saveSimplifiedMultiLevelQuote(quote)).thenAnswer((_) async {});
+
+    await provider.addQuote(quote);
+
+    expect(provider.quotes.contains(quote), isTrue);
+    verify(() => db.saveSimplifiedMultiLevelQuote(quote)).called(1);
+  });
+
+  test('updateQuote updates existing item', () async {
+    final quote = SimplifiedMultiLevelQuote(customerId: '1');
+    provider.quotes.add(quote);
+
+    final updated = SimplifiedMultiLevelQuote(id: quote.id, customerId: '1');
+    when(() => db.saveSimplifiedMultiLevelQuote(updated)).thenAnswer((_) async {});
+
+    await provider.updateQuote(updated);
+
+    expect(provider.quotes.first.id, updated.id);
+  });
+
+  test('deleteQuote removes item from list', () async {
+    final quote = SimplifiedMultiLevelQuote(customerId: '1');
+    provider.quotes.add(quote);
+    when(() => db.deleteSimplifiedMultiLevelQuote(quote.id)).thenAnswer((_) async {});
+
+    await provider.deleteQuote(quote.id);
+
+    expect(provider.quotes, isEmpty);
+  });
+}

--- a/test/providers/template_provider_test.dart
+++ b/test/providers/template_provider_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rufko/providers/template_provider.dart';
+import 'package:rufko/models/pdf_template.dart';
+import 'package:rufko/models/message_template.dart';
+import 'package:rufko/models/email_template.dart';
+import 'package:rufko/models/template_category.dart';
+import 'package:rufko/services/database_service.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockDatabaseService db;
+  late TemplateProvider provider;
+
+  setUp(() {
+    db = MockDatabaseService();
+    provider = TemplateProvider(database: db);
+  });
+
+  test('loadTemplates populates lists', () async {
+    final pdf = PDFTemplate(templateName: 't', pdfFilePath: 'a', pageWidth: 1, pageHeight: 1);
+    when(() => db.getAllPDFTemplates()).thenAnswer((_) async => [pdf]);
+    when(() => db.getAllMessageTemplates()).thenAnswer((_) async => <MessageTemplate>[]);
+    when(() => db.getAllEmailTemplates()).thenAnswer((_) async => <EmailTemplate>[]);
+    when(() => db.getRawCategoriesBoxValues()).thenReturn(<TemplateCategory>[]);
+
+    await provider.loadTemplates();
+
+    expect(provider.pdfTemplates, [pdf]);
+  });
+
+  test('addPDFTemplate adds item', () async {
+    final pdf = PDFTemplate(templateName: 't', pdfFilePath: 'a', pageWidth: 1, pageHeight: 1);
+    when(() => db.savePDFTemplate(pdf)).thenAnswer((_) async {});
+
+    await provider.addPDFTemplate(pdf);
+
+    expect(provider.pdfTemplates.contains(pdf), isTrue);
+    verify(() => db.savePDFTemplate(pdf)).called(1);
+  });
+
+  test('updatePDFTemplate updates item', () async {
+    final pdf = PDFTemplate(templateName: 't', pdfFilePath: 'a', pageWidth: 1, pageHeight: 1);
+    provider.pdfTemplates.add(pdf);
+    final updated = PDFTemplate(id: pdf.id, templateName: 'u', pdfFilePath: 'b', pageWidth: 1, pageHeight: 1);
+    when(() => db.savePDFTemplate(updated)).thenAnswer((_) async {});
+
+    await provider.updatePDFTemplate(updated);
+
+    expect(provider.pdfTemplates.first.templateName, 'u');
+  });
+
+  test('deletePDFTemplate removes item', () async {
+    final pdf = PDFTemplate(templateName: 't', pdfFilePath: 'a', pageWidth: 1, pageHeight: 1);
+    provider.pdfTemplates.add(pdf);
+    when(() => db.deletePDFTemplate(pdf.id)).thenAnswer((_) async {});
+
+    await provider.deletePDFTemplate(pdf.id);
+
+    expect(provider.pdfTemplates, isEmpty);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,7 +14,7 @@ void main() {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const RufkoApp());
 
-    // Verify that our app starts properly
-    expect(find.text('Rufko Dashboard'), findsOneWidget);
+    // Verify that the dashboard tab is visible
+    expect(find.text('Dashboard'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- make providers accept an optional database for easier testing
- add `mocktail` for mocking
- cover CRUD operations in new provider unit tests
- test the dashboard and customers screen widgets
- fix existing widget test for dashboard tab

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68427915bccc832cbba46d9eb16e07f6