### PR TITLE
Fix analyzer errors

### DIFF
--- a/lib/screens/pdf_preview_screen.dart
+++ b/lib/screens/pdf_preview_screen.dart
@@ -2251,7 +2251,41 @@ ${_getCompanyName()}
     );
   }
 
-  // Show field selector dialog - DEBUGGING TOOL
+  // Clear all form field edits
+  void _discardEdits() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear All Edits?'),
+        content: const Text(
+          'This will remove all changes you have made to the PDF form fields.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              setState(() {
+                _editedValues.clear();
+                _editHistory.clear();
+                _currentHistoryIndex = -1;
+                _selectedField = null;
+                _hasEdits = false;
+              });
+            },
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+
+}
+
+// Show field selector dialog - DEBUGGING TOOL
 
 // Custom painter for form field overlays - IMPROVED
 class FormFieldOverlayPainter extends CustomPainter {

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -360,10 +360,15 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   void _showFieldMappingDialog(Map<String, dynamic> pdfFieldInfo) {
     final pdfFieldName = pdfFieldInfo['name'] as String? ?? 'Unknown Field';
 
-    // Check if this PDF field is already mapped
-    FieldMapping? existingMapping;
+    // Find existing mapping for this PDF field if any
+    FieldMapping? currentMapping;
     try {
-    final pdfFieldName = pdfFieldInfo['name'] as String? ?? 'Unknown Field';
+      currentMapping = _currentTemplate!.fieldMappings.firstWhere(
+        (m) => m.pdfFormFieldName == pdfFieldName,
+      );
+    } catch (e) {
+      currentMapping = null;
+    }
 
     showModalBottomSheet(
       context: context,
@@ -389,10 +394,11 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
                           'PDF Field: $pdfFieldName',
                           style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                         ),
-                        Text(
-                          'Linked to: ${PDFTemplate.getFieldDisplayName(mapping.appDataType)}',
-                          style: TextStyle(color: Colors.green.shade700, fontSize: 14),
-                        ),
+                        if (currentMapping != null && currentMapping.pdfFormFieldName.isNotEmpty)
+                          Text(
+                            'Linked to: ${PDFTemplate.getFieldDisplayName(currentMapping.appDataType)}',
+                            style: TextStyle(color: Colors.green.shade700, fontSize: 14),
+                          ),
                       ],
                     ),
                   ),
@@ -400,23 +406,24 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
               ),
               const SizedBox(height: 24),
 
-              // Action buttons
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton.icon(
-                  onPressed: () {
-                    Navigator.pop(context);
-                    _unlinkField(mapping);
-                  },
-                  icon: const Icon(Icons.link_off),
-                  label: const Text('Unlink Field'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.orange,
-                    foregroundColor: Colors.white,
+              if (currentMapping != null && currentMapping.pdfFormFieldName.isNotEmpty) ...[
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      _unlinkField(currentMapping);
+                    },
+                    icon: const Icon(Icons.link_off),
+                    label: const Text('Unlink Field'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange,
+                      foregroundColor: Colors.white,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 8),
+                const SizedBox(height: 8),
+              ],
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton.icon(

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -2241,8 +2241,6 @@ class _TemplatesScreenState extends State<TemplatesScreen>
     );
   }
 
-  }
-
   // NEW MESSAGE TEMPLATE CARD BUILDERS
   Widget _buildSelectableMessageCard(MessageTemplate template) {
     final isSelected = _selectedMessageIds.contains(template.id);


### PR DESCRIPTION
## Summary
- implement `_discardEdits` and close `_PdfPreviewScreenState`
- clean up `_showFieldMappingDialog` implementation
- remove stray closing brace in `templates_screen`

## Testing
- `dart`/`flutter` unavailable in environment; no tests run

------
https://chatgpt.com/codex/tasks/task_e_68428e0ab594832c9c006a89355fd4eb