### PR TITLE
Fix nullability issue in template editor

### DIFF
--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -412,7 +412,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
                   child: ElevatedButton.icon(
                     onPressed: () {
                       Navigator.pop(context);
-                      _unlinkField(currentMapping);
+                      _unlinkField(currentMapping!);
                     },
                     icon: const Icon(Icons.link_off),
                     label: const Text('Unlink Field'),


### PR DESCRIPTION
## Summary
- fix null check warning when unlinking field in `template_editor_screen`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842959251ec832cbc501936f6f6c584