### PR TITLE
Refactor: share utils and cleanup

### DIFF
--- a/lib/mixins/file_sharing_mixin.dart
+++ b/lib/mixins/file_sharing_mixin.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:file_picker/file_picker.dart';
 import '../models/customer.dart';
+import '../utils/common_utils.dart';
 
 mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
   bool _isSharing = false;
@@ -18,83 +19,13 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
     return fileName.split('.').last.toLowerCase();
   }
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
+  // Removed: _formatFileSize -> use formatFileSize from common_utils.dart
 
-  IconData _getFileIcon(String fileType) {
-    switch (fileType.toLowerCase()) {
-      case 'pdf':
-        return Icons.picture_as_pdf;
-      case 'jpg':
-      case 'jpeg':
-      case 'png':
-      case 'gif':
-      case 'webp':
-        return Icons.image;
-      case 'doc':
-      case 'docx':
-        return Icons.description;
-      case 'xls':
-      case 'xlsx':
-        return Icons.table_chart;
-      default:
-        return Icons.insert_drive_file;
-    }
-  }
+  // Removed: _getFileIcon -> use getFileIcon from common_utils.dart
 
-  Color _getFileColor(String fileType) {
-    switch (fileType.toLowerCase()) {
-      case 'pdf':
-        return Colors.red;
-      case 'jpg':
-      case 'jpeg':
-      case 'png':
-      case 'gif':
-      case 'webp':
-        return Colors.blue;
-      case 'doc':
-      case 'docx':
-        return Colors.indigo;
-      case 'xls':
-      case 'xlsx':
-        return Colors.green;
-      default:
-        return Colors.grey;
-    }
-  }
+  // Removed: _getFileColor -> use getFileColor from common_utils.dart
 
-  String _getMimeType(String fileName) {
-    final extension = fileName.split('.').last.toLowerCase();
-    switch (extension) {
-      case 'pdf':
-        return 'application/pdf';
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'png':
-        return 'image/png';
-      case 'gif':
-        return 'image/gif';
-      case 'webp':
-        return 'image/webp';
-      case 'doc':
-        return 'application/msword';
-      case 'docx':
-        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-      case 'xls':
-        return 'application/vnd.ms-excel';
-      case 'xlsx':
-        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-      case 'txt':
-        return 'text/plain';
-      default:
-        return 'application/octet-stream';
-    }
-  }
+  // Removed: _getMimeType -> use getMimeType from common_utils.dart
 
   void _showShareSuccessMessage(String message) {
     if (mounted) {
@@ -182,7 +113,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
               Row(
                 children: [
                   Icon(
-                    _getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
+                    getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
                     size: 24,
                     color: const Color(0xFF2E86AB),
                   ),
@@ -222,9 +153,9 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                 child: Row(
                   children: [
                     Icon(
-                      _getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
+                      getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
                       size: 40,
-                      color: _getFileColor(fileType ?? _getFileTypeFromExtension(fileName)),
+                      color: getFileColor(fileType ?? _getFileTypeFromExtension(fileName)),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
@@ -240,7 +171,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                             future: file.length(),
                             builder: (context, snapshot) {
                               return Text(
-                                'Size: ${snapshot.hasData ? _formatFileSize(snapshot.data!) : 'Calculating...'}',
+                              'Size: ${snapshot.hasData ? formatFileSize(snapshot.data!) : 'Calculating...'}',
                                 style: TextStyle(fontSize: 12, color: Colors.grey[600]),
                               );
                             },
@@ -506,7 +437,7 @@ ${_getCompanyName()}
       await SharePlus.instance.share(
         ShareParams(
           text: 'File: $fileName${customer != null ? ' - ${customer.name}' : ''}',
-          files: [XFile(file.path, mimeType: _getMimeType(fileName))],
+          files: [XFile(file.path, mimeType: getMimeType(fileName))],
         ),
       );
 

--- a/lib/models/pdf_template.dart
+++ b/lib/models/pdf_template.dart
@@ -3,6 +3,7 @@
 import 'package:hive/hive.dart';
 import 'package:uuid/uuid.dart';
 import 'product.dart'; // 🔧 ADDED IMPORT FOR PRODUCT
+import '../utils/common_utils.dart';
 
 part 'pdf_template.g.dart'; // This will be regenerated
 
@@ -317,7 +318,7 @@ class PDFTemplate extends HiveObject {
       // Process each custom field category
       customFieldsByCategory.forEach((customCategoryKey, customFields) {
         final targetCategoryName = categoryMappings[customCategoryKey] ??
-            _formatCategoryName(customCategoryKey);
+            '${formatCategoryName(customCategoryKey)} Fields';
 
         // Check if target category already exists (case-insensitive)
         String? existingCategoryKey;
@@ -351,13 +352,7 @@ class PDFTemplate extends HiveObject {
     return categories;
   }
 
-// Helper method to format category names nicely
-  static String _formatCategoryName(String categoryKey) {
-    return '${categoryKey
-        .split('_')
-        .map((word) => word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
-        .join(' ')} Fields';
-  }
+// Removed: _formatCategoryName -> use formatCategoryName from common_utils.dart
 
   // 🚀 UPDATED: Enhanced getFieldDisplayName method to handle dynamic product names
   // 🚀 UPDATED: Enhanced getFieldDisplayName method to handle custom fields

--- a/lib/screens/custom_app_data_screen.dart
+++ b/lib/screens/custom_app_data_screen.dart
@@ -7,6 +7,7 @@ import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
 import '../widgets/add_custom_field_dialog.dart';
 import '../widgets/edit_custom_field_dialog.dart';
+import '../utils/common_utils.dart';
 
 class CustomAppDataScreen extends StatefulWidget {
   const CustomAppDataScreen({super.key});
@@ -374,7 +375,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
     return FutureBuilder<Map<String, List<Map<String, dynamic>>>>(
       future: context.read<AppStateProvider>().getAllTemplateCategories(),
       builder: (context, snapshot) {
-        String categoryDisplayName = _formatCategoryName(category);
+        String categoryDisplayName = formatCategoryName(category);
 
         if (snapshot.hasData) {
           final allCategories = snapshot.data!;
@@ -758,12 +759,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
     super.dispose();
   }
 
-  String _formatCategoryName(String categoryKey) {
-    return categoryKey
-        .split('_')
-        .map((word) => word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
-        .join(' ');
-  }
+  // Removed: _formatCategoryName -> use formatCategoryName from common_utils.dart
 
   void _showEditFieldDialog(CustomAppDataField field) {
     if (!mounted) return;
@@ -788,7 +784,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
             // Build available categories including current field's category
             final availableCategories = <String>[field.category];
             final categoryNames = <String, String>{
-              field.category: _formatCategoryName(field.category)
+              field.category: formatCategoryName(field.category)
             };
 
             for (final category in customFieldCategories) {
@@ -807,7 +803,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                 availableCategories.add(defaultCat);
                 categoryNames[defaultCat] = defaultCat == 'inspection'
                     ? 'Inspection Fields'
-                    : _formatCategoryName(defaultCat);
+                    : formatCategoryName(defaultCat);
               }
             }
 

--- a/lib/screens/customer_detail/category_media_screen.dart
+++ b/lib/screens/customer_detail/category_media_screen.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../utils/common_utils.dart';
+
 import '../../models/project_media.dart';
 
 class CategoryMediaScreen extends StatelessWidget {
@@ -25,7 +27,7 @@ class CategoryMediaScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(_formatCategoryName(category)),
+            Text(formatCategoryName(category)),
             Text(
               '$customerName • ${mediaItems.length} items',
               style: const TextStyle(fontSize: 12, fontWeight: FontWeight.normal),
@@ -121,10 +123,5 @@ class CategoryMediaScreen extends StatelessWidget {
     );
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
+  // Removed: _formatCategoryName -> use formatCategoryName from common_utils.dart
 }

--- a/lib/screens/customer_detail/media_details_dialog.dart
+++ b/lib/screens/customer_detail/media_details_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import '../../utils/common_utils.dart';
 
 import '../../models/project_media.dart';
 class MediaDetailsDialog extends StatefulWidget {
@@ -23,8 +24,8 @@ class MediaDetailsDialog extends StatefulWidget {
   })  : mediaItem = null,
         onSave = null;
 
-  // Edit constructor - REMOVE CONST HERE
-  MediaDetailsDialog.edit({ // <<<< REMOVED 'const'
+  // Edit constructor - non-const
+  MediaDetailsDialog.edit({
     super.key,
     required this.mediaItem,
     required this.onSave,
@@ -174,7 +175,7 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
                                       ),
                                       Text(
                                         widget.fileSize != null
-                                            ? _formatFileSize(widget.fileSize!)
+                                            ? formatFileSize(widget.fileSize!)
                                             : 'Unknown size',
                                         style: TextStyle(
                                           color: Colors.grey[600],
@@ -208,7 +209,7 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
                         items: _categories.map((category) {
                           return DropdownMenuItem(
                             value: category,
-                            child: Text(_formatCategoryName(category)),
+                            child: Text(formatCategoryName(category)),
                           );
                         }).toList(),
                         onChanged: (value) {
@@ -369,18 +370,8 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
     }
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
+  // Removed: _formatCategoryName -> use formatCategoryName from common_utils.dart
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
+  // Removed: _formatFileSize -> use formatFileSize from common_utils.dart
 }
 

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 import 'dart:io';
+import '../utils/common_utils.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:open_filex/open_filex.dart';
@@ -4232,7 +4233,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                               overflow: TextOverflow.ellipsis,
                             ),
                             Text(
-                              _formatFileSize(fileSize),
+                              formatFileSize(fileSize),
                               style: TextStyle(
                                 color: Colors.grey[600],
                                 fontSize: 12,
@@ -4312,12 +4313,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
     }
   }
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
+  // Removed: _formatFileSize -> use formatFileSize from common_utils.dart
 
 
 
@@ -4533,12 +4529,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
     }
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
+  // Removed: _formatCategoryName -> use formatCategoryName from common_utils.dart
 
   Widget _buildMediaTypeHeader(String title, IconData icon, int count, Color color) {
     return Row(
@@ -4702,7 +4693,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       case 'other_photos':
         return 'Other Photos';
       default:
-        return _formatCategoryName(category);
+        return formatCategoryName(category);
     }
   }
 

--- a/lib/screens/pdf_preview_screen.dart
+++ b/lib/screens/pdf_preview_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
+import '../utils/common_utils.dart';
 import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
 import 'package:syncfusion_flutter_pdf/pdf.dart' as sf_pdf;
 import '../providers/app_state_provider.dart';
@@ -1364,7 +1365,7 @@ class _PdfPreviewScreenState extends State<PdfPreviewScreen> {
                             future: fileToShare.length(),
                             builder: (context, snapshot) {
                               return Text(
-                                'Size: ${snapshot.hasData ? _formatFileSize(snapshot.data!) : 'Calculating...'}',
+                                'Size: ${snapshot.hasData ? formatFileSize(snapshot.data!) : 'Calculating...'}',
                                 style: TextStyle(fontSize: 12, color: Colors.grey[600]),
                               );
                             },
@@ -2081,13 +2082,7 @@ ${_getCompanyName()}
     }
   }
 
-// Format file size helper
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
+// Removed: _formatFileSize -> use formatFileSize from common_utils.dart
 
   // Discard PDF
   void _discardPdf() {

--- a/lib/services/simple_pdf_editing_service.dart
+++ b/lib/services/simple_pdf_editing_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:syncfusion_flutter_pdf/pdf.dart' as syncfusion;
 import 'package:path_provider/path_provider.dart';
 import '../models/project_media.dart';
+import '../utils/common_utils.dart';
 
 enum EditingTool {
   none,
@@ -380,7 +381,7 @@ class SimplePdfEditingService {
         'hasFormFields': document.form.fields.count > 0,
         'formFieldCount': document.form.fields.count,
         'fileSize': bytes.length,
-        'fileSizeFormatted': _formatFileSize(bytes.length),
+        'fileSizeFormatted': formatFileSize(bytes.length),
         'canEdit': document.form.fields.count > 0,
       };
 
@@ -401,10 +402,5 @@ class SimplePdfEditingService {
     }
   }
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
+  // Removed: _formatFileSize -> use formatFileSize from common_utils.dart
 }

--- a/lib/utils/common_utils.dart
+++ b/lib/utils/common_utils.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+String formatFileSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+}
+
+String formatCategoryName(String key) {
+  return key
+      .split('_')
+      .map((word) => word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
+      .join(' ');
+}
+
+IconData getFileIcon(String fileType) {
+  switch (fileType.toLowerCase()) {
+    case 'pdf':
+      return Icons.picture_as_pdf;
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'webp':
+      return Icons.image;
+    case 'doc':
+    case 'docx':
+      return Icons.description;
+    case 'xls':
+    case 'xlsx':
+      return Icons.table_chart;
+    default:
+      return Icons.insert_drive_file;
+  }
+}
+
+Color getFileColor(String fileType) {
+  switch (fileType.toLowerCase()) {
+    case 'pdf':
+      return Colors.red;
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'webp':
+      return Colors.blue;
+    case 'doc':
+    case 'docx':
+      return Colors.indigo;
+    case 'xls':
+    case 'xlsx':
+      return Colors.green;
+    default:
+      return Colors.grey;
+  }
+}
+
+String getMimeType(String fileName) {
+  final extension = fileName.split('.').last.toLowerCase();
+  switch (extension) {
+    case 'pdf':
+      return 'application/pdf';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'gif':
+      return 'image/gif';
+    case 'webp':
+      return 'image/webp';
+    case 'doc':
+      return 'application/msword';
+    case 'docx':
+      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    case 'xls':
+      return 'application/vnd.ms-excel';
+    case 'xlsx':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    case 'txt':
+      return 'text/plain';
+    default:
+      return 'application/octet-stream';
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `formatFileSize`, `formatCategoryName`, and file helpers in `common_utils.dart`
- refactor screens, mixins and services to use these new utilities
- note removal of old private implementations
- clean up constructor comment in `MediaDetailsDialog`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684299f40794832caf37781d1e929dc6