### PR TITLE
Refactor helpers into common_utils

### DIFF
--- a/lib/mixins/file_sharing_mixin.dart
+++ b/lib/mixins/file_sharing_mixin.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:file_picker/file_picker.dart';
 import '../models/customer.dart';
+import '../utils/common_utils.dart';
 
 mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
   bool _isSharing = false;
@@ -16,84 +17,6 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
 
   String _getFileTypeFromExtension(String fileName) {
     return fileName.split('.').last.toLowerCase();
-  }
-
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
-
-  IconData _getFileIcon(String fileType) {
-    switch (fileType.toLowerCase()) {
-      case 'pdf':
-        return Icons.picture_as_pdf;
-      case 'jpg':
-      case 'jpeg':
-      case 'png':
-      case 'gif':
-      case 'webp':
-        return Icons.image;
-      case 'doc':
-      case 'docx':
-        return Icons.description;
-      case 'xls':
-      case 'xlsx':
-        return Icons.table_chart;
-      default:
-        return Icons.insert_drive_file;
-    }
-  }
-
-  Color _getFileColor(String fileType) {
-    switch (fileType.toLowerCase()) {
-      case 'pdf':
-        return Colors.red;
-      case 'jpg':
-      case 'jpeg':
-      case 'png':
-      case 'gif':
-      case 'webp':
-        return Colors.blue;
-      case 'doc':
-      case 'docx':
-        return Colors.indigo;
-      case 'xls':
-      case 'xlsx':
-        return Colors.green;
-      default:
-        return Colors.grey;
-    }
-  }
-
-  String _getMimeType(String fileName) {
-    final extension = fileName.split('.').last.toLowerCase();
-    switch (extension) {
-      case 'pdf':
-        return 'application/pdf';
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'png':
-        return 'image/png';
-      case 'gif':
-        return 'image/gif';
-      case 'webp':
-        return 'image/webp';
-      case 'doc':
-        return 'application/msword';
-      case 'docx':
-        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-      case 'xls':
-        return 'application/vnd.ms-excel';
-      case 'xlsx':
-        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-      case 'txt':
-        return 'text/plain';
-      default:
-        return 'application/octet-stream';
-    }
   }
 
   void _showShareSuccessMessage(String message) {
@@ -182,7 +105,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
               Row(
                 children: [
                   Icon(
-                    _getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
+                    getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
                     size: 24,
                     color: const Color(0xFF2E86AB),
                   ),
@@ -222,9 +145,9 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                 child: Row(
                   children: [
                     Icon(
-                      _getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
+                      getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
                       size: 40,
-                      color: _getFileColor(fileType ?? _getFileTypeFromExtension(fileName)),
+                      color: getFileColor(fileType ?? _getFileTypeFromExtension(fileName)),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
@@ -240,7 +163,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                             future: file.length(),
                             builder: (context, snapshot) {
                               return Text(
-                                'Size: ${snapshot.hasData ? _formatFileSize(snapshot.data!) : 'Calculating...'}',
+                                'Size: ${snapshot.hasData ? formatFileSize(snapshot.data!) : 'Calculating...'}',
                                 style: TextStyle(fontSize: 12, color: Colors.grey[600]),
                               );
                             },
@@ -506,7 +429,7 @@ ${_getCompanyName()}
       await SharePlus.instance.share(
         ShareParams(
           text: 'File: $fileName${customer != null ? ' - ${customer.name}' : ''}',
-          files: [XFile(file.path, mimeType: _getMimeType(fileName))],
+          files: [XFile(file.path, mimeType: getMimeType(fileName))],
         ),
       );
 

--- a/lib/models/pdf_template.dart
+++ b/lib/models/pdf_template.dart
@@ -3,6 +3,7 @@
 import 'package:hive/hive.dart';
 import 'package:uuid/uuid.dart';
 import 'product.dart'; // 🔧 ADDED IMPORT FOR PRODUCT
+import '../utils/common_utils.dart';
 
 part 'pdf_template.g.dart'; // This will be regenerated
 
@@ -316,8 +317,9 @@ class PDFTemplate extends HiveObject {
 
       // Process each custom field category
       customFieldsByCategory.forEach((customCategoryKey, customFields) {
-        final targetCategoryName = categoryMappings[customCategoryKey] ??
-            _formatCategoryName(customCategoryKey);
+        final targetCategoryName =
+            categoryMappings[customCategoryKey] ??
+                formatCategoryName(customCategoryKey);
 
         // Check if target category already exists (case-insensitive)
         String? existingCategoryKey;
@@ -351,13 +353,6 @@ class PDFTemplate extends HiveObject {
     return categories;
   }
 
-// Helper method to format category names nicely
-  static String _formatCategoryName(String categoryKey) {
-    return '${categoryKey
-        .split('_')
-        .map((word) => word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
-        .join(' ')} Fields';
-  }
 
   // 🚀 UPDATED: Enhanced getFieldDisplayName method to handle dynamic product names
   // 🚀 UPDATED: Enhanced getFieldDisplayName method to handle custom fields

--- a/lib/screens/custom_app_data_screen.dart
+++ b/lib/screens/custom_app_data_screen.dart
@@ -7,6 +7,7 @@ import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
 import '../widgets/add_custom_field_dialog.dart';
 import '../widgets/edit_custom_field_dialog.dart';
+import '../utils/common_utils.dart';
 
 class CustomAppDataScreen extends StatefulWidget {
   const CustomAppDataScreen({super.key});
@@ -374,7 +375,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
     return FutureBuilder<Map<String, List<Map<String, dynamic>>>>(
       future: context.read<AppStateProvider>().getAllTemplateCategories(),
       builder: (context, snapshot) {
-        String categoryDisplayName = _formatCategoryName(category);
+        String categoryDisplayName = formatCategoryName(category);
 
         if (snapshot.hasData) {
           final allCategories = snapshot.data!;
@@ -758,12 +759,6 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
     super.dispose();
   }
 
-  String _formatCategoryName(String categoryKey) {
-    return categoryKey
-        .split('_')
-        .map((word) => word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
-        .join(' ');
-  }
 
   void _showEditFieldDialog(CustomAppDataField field) {
     if (!mounted) return;
@@ -788,7 +783,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
             // Build available categories including current field's category
             final availableCategories = <String>[field.category];
             final categoryNames = <String, String>{
-              field.category: _formatCategoryName(field.category)
+              field.category: formatCategoryName(field.category)
             };
 
             for (final category in customFieldCategories) {
@@ -807,7 +802,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                 availableCategories.add(defaultCat);
                 categoryNames[defaultCat] = defaultCat == 'inspection'
                     ? 'Inspection Fields'
-                    : _formatCategoryName(defaultCat);
+                    : formatCategoryName(defaultCat);
               }
             }
 

--- a/lib/screens/customer_detail/category_media_screen.dart
+++ b/lib/screens/customer_detail/category_media_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../models/project_media.dart';
+import '../../utils/common_utils.dart';
 
 class CategoryMediaScreen extends StatelessWidget {
   final String category;
@@ -25,7 +26,7 @@ class CategoryMediaScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(_formatCategoryName(category)),
+            Text(formatCategoryName(category)),
             Text(
               '$customerName • ${mediaItems.length} items',
               style: const TextStyle(fontSize: 12, fontWeight: FontWeight.normal),
@@ -121,10 +122,4 @@ class CategoryMediaScreen extends StatelessWidget {
     );
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
 }

--- a/lib/screens/customer_detail/media_details_dialog.dart
+++ b/lib/screens/customer_detail/media_details_dialog.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import '../../models/project_media.dart';
+import '../../utils/common_utils.dart';
 class MediaDetailsDialog extends StatefulWidget {
   final File? file;
   final String? fileName;
@@ -174,7 +175,7 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
                                       ),
                                       Text(
                                         widget.fileSize != null
-                                            ? _formatFileSize(widget.fileSize!)
+                                            ? formatFileSize(widget.fileSize!)
                                             : 'Unknown size',
                                         style: TextStyle(
                                           color: Colors.grey[600],
@@ -208,7 +209,7 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
                         items: _categories.map((category) {
                           return DropdownMenuItem(
                             value: category,
-                            child: Text(_formatCategoryName(category)),
+                            child: Text(formatCategoryName(category)),
                           );
                         }).toList(),
                         onChanged: (value) {
@@ -369,18 +370,5 @@ class _MediaDetailsDialogState extends State<MediaDetailsDialog> {
     }
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
-
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
 }
 

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' as path;
+import '../utils/common_utils.dart';
 import 'dart:math' as math;
 import 'package:url_launcher/url_launcher.dart';
 import '../models/customer.dart';
@@ -4259,7 +4260,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                               overflow: TextOverflow.ellipsis,
                             ),
                             Text(
-                              _formatFileSize(fileSize),
+                              formatFileSize(fileSize),
                               style: TextStyle(
                                 color: Colors.grey[600],
                                 fontSize: 12,
@@ -4339,12 +4340,6 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
     }
   }
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
 
 
 
@@ -4560,12 +4555,6 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
     }
   }
 
-  String _formatCategoryName(String category) {
-    return category
-        .split('_')
-        .map((word) => word[0].toUpperCase() + word.substring(1))
-        .join(' ');
-  }
 
   Widget _buildMediaTypeHeader(String title, IconData icon, int count, Color color) {
     return Row(
@@ -4729,7 +4718,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       case 'other_photos':
         return 'Other Photos';
       default:
-        return _formatCategoryName(category);
+        return formatCategoryName(category);
     }
   }
 

--- a/lib/services/simple_pdf_editing_service.dart
+++ b/lib/services/simple_pdf_editing_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:syncfusion_flutter_pdf/pdf.dart' as syncfusion;
 import 'package:path_provider/path_provider.dart';
 import '../models/project_media.dart';
+import '../utils/common_utils.dart';
 
 enum EditingTool {
   none,
@@ -380,7 +381,7 @@ class SimplePdfEditingService {
         'hasFormFields': document.form.fields.count > 0,
         'formFieldCount': document.form.fields.count,
         'fileSize': bytes.length,
-        'fileSizeFormatted': _formatFileSize(bytes.length),
+        'fileSizeFormatted': formatFileSize(bytes.length),
         'canEdit': document.form.fields.count > 0,
       };
 
@@ -401,10 +402,4 @@ class SimplePdfEditingService {
     }
   }
 
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
 }

--- a/lib/utils/common_utils.dart
+++ b/lib/utils/common_utils.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+String formatFileSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+}
+
+String formatCategoryName(String key) {
+  return key
+      .split('_')
+      .map((word) =>
+          word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : '')
+      .join(' ');
+}
+
+IconData getFileIcon(String fileType) {
+  switch (fileType.toLowerCase()) {
+    case 'pdf':
+      return Icons.picture_as_pdf;
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'webp':
+      return Icons.image;
+    case 'doc':
+    case 'docx':
+      return Icons.description;
+    case 'xls':
+    case 'xlsx':
+      return Icons.table_chart;
+    default:
+      return Icons.insert_drive_file;
+  }
+}
+
+Color getFileColor(String fileType) {
+  switch (fileType.toLowerCase()) {
+    case 'pdf':
+      return Colors.red;
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'webp':
+      return Colors.blue;
+    case 'doc':
+    case 'docx':
+      return Colors.indigo;
+    case 'xls':
+    case 'xlsx':
+      return Colors.green;
+    default:
+      return Colors.grey;
+  }
+}
+
+String getMimeType(String fileName) {
+  final extension = fileName.split('.').last.toLowerCase();
+  switch (extension) {
+    case 'pdf':
+      return 'application/pdf';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'gif':
+      return 'image/gif';
+    case 'webp':
+      return 'image/webp';
+    case 'doc':
+      return 'application/msword';
+    case 'docx':
+      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    case 'xls':
+      return 'application/vnd.ms-excel';
+    case 'xlsx':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    case 'txt':
+      return 'text/plain';
+    default:
+      return 'application/octet-stream';
+  }
+}


### PR DESCRIPTION
## Summary
- centralize formatting and file helper functions in `common_utils.dart`
- update `FileSharingMixin` to use new helpers
- remove duplicate helpers from dialogs and screens
- switch PDF editing service and others to call shared helpers

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684298cae5b8832c8d314177f158457c