### PR TITLE
Refactor duplicated helpers into mixins

### DIFF
--- a/lib/mixins/empty_state_mixin.dart
+++ b/lib/mixins/empty_state_mixin.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+mixin EmptyStateMixin<T extends StatefulWidget> on State<T> {
+  Widget buildEmptyState({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+  }) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 64, color: Colors.grey),
+          const SizedBox(height: 16),
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(subtitle, style: Theme.of(context).textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/mixins/field_type_mixin.dart
+++ b/lib/mixins/field_type_mixin.dart
@@ -1,0 +1,26 @@
+mixin FieldTypeMixin {
+  static const List<String> fieldTypesConst = [
+    'text',
+    'number',
+    'email',
+    'phone',
+    'multiline',
+    'date',
+    'currency',
+    'checkbox',
+  ];
+
+  static const Map<String, String> fieldTypeNamesConst = {
+    'text': 'Text',
+    'number': 'Number',
+    'email': 'Email',
+    'phone': 'Phone',
+    'multiline': 'Multi-line Text',
+    'date': 'Date',
+    'currency': 'Currency',
+    'checkbox': 'Checkbox',
+  };
+
+  List<String> get fieldTypes => fieldTypesConst;
+  Map<String, String> get fieldTypeNames => fieldTypeNamesConst;
+}

--- a/lib/mixins/search_mixin.dart
+++ b/lib/mixins/search_mixin.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+mixin SearchMixin<T extends StatefulWidget> on State<T> {
+  final TextEditingController searchController = TextEditingController();
+  String searchQuery = '';
+  bool showSearch = false;
+
+  void toggleSearch() {
+    setState(() {
+      showSearch = !showSearch;
+      if (!showSearch) clearSearch();
+    });
+  }
+
+  void clearSearch() {
+    searchController.clear();
+    setState(() => searchQuery = '');
+  }
+
+  @mustCallSuper
+  void disposeSearch() {
+    searchController.dispose();
+  }
+}

--- a/lib/mixins/sort_menu_mixin.dart
+++ b/lib/mixins/sort_menu_mixin.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+mixin SortMenuMixin<T extends StatefulWidget> on State<T> {
+  PopupMenuItem<String> buildSortMenuItem({
+    required String label,
+    required IconData icon,
+    required String value,
+    required String currentSortBy,
+    required bool sortAscending,
+  }) {
+    return PopupMenuItem(
+      value: value,
+      child: Row(
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 8),
+          Text(label),
+          if (currentSortBy == value) ...[
+            const Spacer(),
+            Icon(
+              sortAscending ? Icons.arrow_upward : Icons.arrow_downward,
+              size: 16,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/customers_screen.dart
+++ b/lib/screens/customers_screen.dart
@@ -6,6 +6,9 @@ import '../providers/app_state_provider.dart';
 import '../models/customer.dart';
 import '../widgets/customer_card.dart';   // Assuming this will be adapted
 import 'customer_detail_screen.dart';
+import '../mixins/search_mixin.dart';
+import '../mixins/sort_menu_mixin.dart';
+import '../mixins/empty_state_mixin.dart';
 
 class CustomersScreen extends StatefulWidget {
   const CustomersScreen({super.key});
@@ -14,11 +17,10 @@ class CustomersScreen extends StatefulWidget {
   State<CustomersScreen> createState() => _CustomersScreenState();
 }
 
-class _CustomersScreenState extends State<CustomersScreen> with TickerProviderStateMixin {
+class _CustomersScreenState extends State<CustomersScreen>
+    with TickerProviderStateMixin, SearchMixin, SortMenuMixin, EmptyStateMixin {
   late TabController _tabController;
-  final TextEditingController _searchController = TextEditingController();
-  String _searchQuery = '';
-  bool _showSearch = false;
+  // SearchMixin provides searchController, searchQuery and showSearch
   String _sortBy = 'name';
   bool _sortAscending = true;
 
@@ -33,7 +35,7 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
   @override
   void dispose() {
     _tabController.dispose();
-    _searchController.dispose();
+    disposeSearch();
     super.dispose();
   }
 
@@ -48,8 +50,8 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
         elevation: 0,
         actions: [
           IconButton(
-            icon: Icon(_showSearch ? Icons.search_off : Icons.search),
-            onPressed: _toggleSearch,
+            icon: Icon(showSearch ? Icons.search_off : Icons.search),
+            onPressed: toggleSearch,
           ),
           PopupMenuButton<String>(
             icon: const Icon(Icons.sort),
@@ -64,9 +66,27 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
               });
             },
             itemBuilder: (context) => [
-              _buildSortMenuItem('Name', Icons.sort_by_alpha, 'name'),
-              _buildSortMenuItem('Date Added', Icons.calendar_today, 'date'),
-              _buildSortMenuItem('Last Activity', Icons.access_time, 'activity'),
+              buildSortMenuItem(
+                label: 'Name',
+                icon: Icons.sort_by_alpha,
+                value: 'name',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
+              buildSortMenuItem(
+                label: 'Date Added',
+                icon: Icons.calendar_today,
+                value: 'date',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
+              buildSortMenuItem(
+                label: 'Last Activity',
+                icon: Icons.access_time,
+                value: 'activity',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
             ],
           ),
           IconButton(
@@ -75,10 +95,10 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
           ),
         ],
         bottom: PreferredSize(
-          preferredSize: Size.fromHeight(_showSearch ? 120 : 60),
+          preferredSize: Size.fromHeight(showSearch ? 120 : 60),
           child: Column(
             children: [
-              if (_showSearch) _buildSearchBar(),
+              if (showSearch) _buildSearchBar(),
               Container(
                 color: Colors.white,
                 child: TabBar(
@@ -136,41 +156,25 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
           border: Border.all(color: Colors.grey[300]!),
         ),
         child: TextField(
-          controller: _searchController,
+          controller: searchController,
           decoration: InputDecoration(
             hintText: 'Search customers by name, phone, email...',
             hintStyle: TextStyle(color: Colors.grey[500]),
             prefixIcon: Icon(Icons.search, color: Colors.grey[600]),
-            suffixIcon: _searchController.text.isNotEmpty
+            suffixIcon: searchController.text.isNotEmpty
                 ? IconButton(
               icon: Icon(Icons.clear, color: Colors.grey[600]),
-              onPressed: _clearSearch,
+              onPressed: clearSearch,
             ) : null,
             border: InputBorder.none,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           ),
-          onChanged: (value) => setState(() => _searchQuery = value),
+          onChanged: (value) => setState(() => searchQuery = value),
         ),
       ),
     );
   }
 
-  PopupMenuItem<String> _buildSortMenuItem(String label, IconData icon, String value) {
-    return PopupMenuItem(
-      value: value,
-      child: Row(
-        children: [
-          Icon(icon, size: 18),
-          const SizedBox(width: 8),
-          Text(label),
-          if (_sortBy == value) ...[
-            const Spacer(),
-            Icon(_sortAscending ? Icons.arrow_upward : Icons.arrow_downward, size: 16),
-          ],
-        ],
-      ),
-    );
-  }
 
   Widget _buildCustomersList(AppStateProvider appState, String filter) {
     List<Customer> customers = _getFilteredCustomers(appState, filter);
@@ -197,31 +201,20 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
   }
 
   Widget _buildEmptyState(String filter) {
-    final bool noQuery = _searchQuery.isEmpty;
+    final bool noQuery = searchQuery.isEmpty;
     String title = noQuery ? 'No customers yet' : 'No customers found';
     String subtitle =
         noQuery ? 'Add your first customer' : 'Try adjusting search';
     IconData icon = noQuery ? Icons.people_outline : Icons.search_off;
 
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon, size: 64, color: Colors.grey),
-          const SizedBox(height: 16),
-          Text(title, style: Theme.of(context).textTheme.titleMedium),
-          const SizedBox(height: 8),
-          Text(subtitle, style: Theme.of(context).textTheme.bodyMedium),
-        ],
-      ),
-    );
+    return buildEmptyState(icon: icon, title: title, subtitle: subtitle);
   }
 
 
   List<Customer> _getFilteredCustomers(AppStateProvider appState, String filter) {
-    List<Customer> customers = _searchQuery.isEmpty
+    List<Customer> customers = searchQuery.isEmpty
         ? appState.customers
-        : appState.searchCustomers(_searchQuery);
+        : appState.searchCustomers(searchQuery);
 
     switch (filter) {
       case 'Recent':
@@ -272,13 +265,6 @@ class _CustomersScreenState extends State<CustomersScreen> with TickerProviderSt
     return customers;
   }
 
-  void _toggleSearch() {
-    setState(() { _showSearch = !_showSearch; if (!_showSearch) _clearSearch(); });
-  }
-  void _clearSearch() {
-    _searchController.clear();
-    setState(() => _searchQuery = '');
-  }
 
   void _navigateToCustomerDetail(Customer customer) {
     Navigator.push(context, MaterialPageRoute(builder: (context) => CustomerDetailScreen(customer: customer)));

--- a/lib/screens/products_screen.dart
+++ b/lib/screens/products_screen.dart
@@ -5,6 +5,9 @@ import 'package:provider/provider.dart';
 import '../providers/app_state_provider.dart';
 import '../models/product.dart';
 import 'products/product_form_dialog.dart';
+import '../mixins/search_mixin.dart';
+import '../mixins/sort_menu_mixin.dart';
+import '../mixins/empty_state_mixin.dart';
 
 class ProductsScreen extends StatefulWidget {
   const ProductsScreen({super.key});
@@ -13,11 +16,10 @@ class ProductsScreen extends StatefulWidget {
   State<ProductsScreen> createState() => _ProductsScreenState();
 }
 
-class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStateMixin {
+class _ProductsScreenState extends State<ProductsScreen>
+    with TickerProviderStateMixin, SearchMixin, SortMenuMixin, EmptyStateMixin {
   late TabController _tabController;
-  final TextEditingController _searchController = TextEditingController();
-  String _searchQuery = '';
-  bool _showSearch = false;
+  // SearchMixin provides searchController, searchQuery and showSearch
   String _sortBy = 'name';
   bool _sortAscending = true;
 
@@ -42,7 +44,7 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
   @override
   void dispose() {
     _tabController.dispose();
-    _searchController.dispose();
+    disposeSearch();
     super.dispose();
   }
 
@@ -57,8 +59,8 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
         elevation: 0,
         actions: [
           IconButton(
-            icon: Icon(_showSearch ? Icons.search_off : Icons.search),
-            onPressed: _toggleSearch,
+            icon: Icon(showSearch ? Icons.search_off : Icons.search),
+            onPressed: toggleSearch,
           ),
           PopupMenuButton<String>(
             icon: const Icon(Icons.sort),
@@ -73,9 +75,27 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
               });
             },
             itemBuilder: (context) => [
-              _buildSortMenuItem('Name', Icons.sort_by_alpha, 'name'),
-              _buildSortMenuItem('Category', Icons.category, 'category'),
-              _buildSortMenuItem('Price', Icons.attach_money, 'price'),
+              buildSortMenuItem(
+                label: 'Name',
+                icon: Icons.sort_by_alpha,
+                value: 'name',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
+              buildSortMenuItem(
+                label: 'Category',
+                icon: Icons.category,
+                value: 'category',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
+              buildSortMenuItem(
+                label: 'Price',
+                icon: Icons.attach_money,
+                value: 'price',
+                currentSortBy: _sortBy,
+                sortAscending: _sortAscending,
+              ),
             ],
           ),
           IconButton(
@@ -84,10 +104,10 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
           ),
         ],
         bottom: PreferredSize(
-          preferredSize: Size.fromHeight(_showSearch ? 120 : 60),
+          preferredSize: Size.fromHeight(showSearch ? 120 : 60),
           child: Column(
             children: [
-              if (_showSearch) _buildSearchBar(),
+              if (showSearch) _buildSearchBar(),
               Container(
                 color: Colors.white,
                 child: TabBar(
@@ -132,42 +152,26 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
           border: Border.all(color: Colors.grey[300]!),
         ),
         child: TextField(
-          controller: _searchController,
+          controller: searchController,
           decoration: InputDecoration(
             hintText: 'Search products by name, category, SKU...',
             hintStyle: TextStyle(color: Colors.grey[500]),
             prefixIcon: Icon(Icons.search, color: Colors.grey[600]),
-            suffixIcon: _searchController.text.isNotEmpty
+            suffixIcon: searchController.text.isNotEmpty
                 ? IconButton(
               icon: Icon(Icons.clear, color: Colors.grey[600]),
-              onPressed: _clearSearch,
+              onPressed: clearSearch,
             )
                 : null,
             border: InputBorder.none,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           ),
-          onChanged: (value) => setState(() => _searchQuery = value),
+          onChanged: (value) => setState(() => searchQuery = value),
         ),
       ),
     );
   }
 
-  PopupMenuItem<String> _buildSortMenuItem(String label, IconData icon, String value) {
-    return PopupMenuItem(
-      value: value,
-      child: Row(
-        children: [
-          Icon(icon, size: 18),
-          const SizedBox(width: 8),
-          Text(label),
-          if (_sortBy == value) ...[
-            const Spacer(),
-            Icon(_sortAscending ? Icons.arrow_upward : Icons.arrow_downward, size: 16),
-          ],
-        ],
-      ),
-    );
-  }
 
   Widget _buildProductsList(AppStateProvider appState, String categoryFilter) {
     List<Product> productsToDisplay = _getFilteredProducts(appState, categoryFilter);
@@ -377,7 +381,7 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
     IconData icon;
     String title, subtitle;
 
-    if (_searchQuery.isNotEmpty) {
+    if (searchQuery.isNotEmpty) {
       icon = Icons.search_off;
       title = 'No products found';
       subtitle = 'Try adjusting your search terms';
@@ -395,51 +399,27 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Container(
-            padding: const EdgeInsets.all(24),
-            decoration: BoxDecoration(
-              color: Colors.grey.shade100,
-              shape: BoxShape.circle,
-            ),
-            child: Icon(icon, size: 64, color: Colors.grey.shade400),
-          ),
-          const SizedBox(height: 24),
-          Text(
-            title,
-            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              color: Colors.grey[700],
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            subtitle,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Colors.grey[500],
-            ),
-            textAlign: TextAlign.center,
-          ),
+          buildEmptyState(icon: icon, title: title, subtitle: subtitle),
           const SizedBox(height: 32),
-          if (_searchQuery.isEmpty) ...[
+          if (searchQuery.isEmpty)
             ElevatedButton.icon(
               onPressed: () => _showAddProductDialog(context),
               icon: const Icon(Icons.add),
               label: const Text('Add First Product'),
-            ),
-          ] else ...[
+            )
+          else
             OutlinedButton.icon(
-              onPressed: _clearSearch,
+              onPressed: clearSearch,
               icon: const Icon(Icons.clear),
               label: const Text('Clear Search'),
             ),
-          ],
         ],
       ),
     );
   }
 
   List<Product> _getFilteredProducts(AppStateProvider appState, String categoryFilter) {
-    List<Product> products = _searchQuery.isEmpty
+    List<Product> products = searchQuery.isEmpty
         ? appState.products
         : _getSearchResults(appState.products);
 
@@ -468,7 +448,7 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
   }
 
   List<Product> _getSearchResults(List<Product> products) {
-    final lowerQuery = _searchQuery.toLowerCase();
+    final lowerQuery = searchQuery.toLowerCase();
     return products.where((product) =>
     product.name.toLowerCase().contains(lowerQuery) ||
         (product.description?.toLowerCase().contains(lowerQuery) ?? false) ||
@@ -519,19 +499,6 @@ class _ProductsScreenState extends State<ProductsScreen> with TickerProviderStat
     }
   }
 
-  void _toggleSearch() {
-    setState(() {
-      _showSearch = !_showSearch;
-      if (!_showSearch) {
-        _clearSearch();
-      }
-    });
-  }
-
-  void _clearSearch() {
-    _searchController.clear();
-    setState(() => _searchQuery = '');
-  }
 
   void _showProductDetails(Product product) {
     showDialog(

--- a/lib/screens/quotes_screen.dart
+++ b/lib/screens/quotes_screen.dart
@@ -12,6 +12,9 @@ import '../models/roof_scope_data.dart'; // For creating new quotes
 // Import the new screens
 import 'simplified_quote_screen.dart';
 import 'simplified_quote_detail_screen.dart';
+import '../mixins/search_mixin.dart';
+import '../mixins/sort_menu_mixin.dart';
+import '../mixins/empty_state_mixin.dart';
 
 
 
@@ -22,11 +25,10 @@ class QuotesScreen extends StatefulWidget {
   State<QuotesScreen> createState() => _QuotesScreenState();
 }
 
-class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMixin {
+class _QuotesScreenState extends State<QuotesScreen>
+    with TickerProviderStateMixin, SearchMixin, SortMenuMixin, EmptyStateMixin {
   late TabController _tabController;
-  final TextEditingController _searchController = TextEditingController();
-  String _searchQuery = '';
-  bool _showSearch = false;
+  // SearchMixin provides searchController, searchQuery and showSearch
   // String _sortBy = 'date'; // 'date', 'amount', 'customer', 'status' // You can re-add sorting later
   // bool _sortAscending = false;
 
@@ -41,7 +43,7 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
   @override
   void dispose() {
     _tabController.dispose();
-    _searchController.dispose();
+    disposeSearch();
     super.dispose();
   }
 
@@ -56,8 +58,8 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
         elevation: 0,
         actions: [
           IconButton(
-            icon: Icon(_showSearch ? Icons.search_off : Icons.search),
-            onPressed: _toggleSearch,
+            icon: Icon(showSearch ? Icons.search_off : Icons.search),
+            onPressed: toggleSearch,
           ),
           // Sorting can be re-added later if needed
           // PopupMenuButton<String>(...),
@@ -67,10 +69,10 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
           ),
         ],
         bottom: PreferredSize(
-          preferredSize: Size.fromHeight(_showSearch ? 120 : 60),
+          preferredSize: Size.fromHeight(showSearch ? 120 : 60),
           child: Column(
             children: [
-              if (_showSearch) _buildSearchBar(),
+              if (showSearch) _buildSearchBar(),
               Container(
                 color: Colors.white,
                 child: TabBar(
@@ -118,20 +120,20 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
           border: Border.all(color: Colors.grey[300]!),
         ),
         child: TextField(
-          controller: _searchController,
+          controller: searchController,
           decoration: InputDecoration(
             hintText: 'Search quotes by number or customer...',
             hintStyle: TextStyle(color: Colors.grey[500]),
             prefixIcon: Icon(Icons.search, color: Colors.grey[600]),
-            suffixIcon: _searchController.text.isNotEmpty
+            suffixIcon: searchController.text.isNotEmpty
                 ? IconButton(
               icon: Icon(Icons.clear, color: Colors.grey[600]),
-              onPressed: _clearSearch,
+              onPressed: clearSearch,
             ) : null,
             border: InputBorder.none,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           ),
-          onChanged: (value) => setState(() => _searchQuery = value),
+          onChanged: (value) => setState(() => searchQuery = value),
         ),
       ),
     );
@@ -144,8 +146,8 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
     List<SimplifiedMultiLevelQuote> quotes = appState.simplifiedQuotes;
 
     // Apply search filter
-    if (_searchQuery.isNotEmpty) {
-      final lowerQuery = _searchQuery.toLowerCase();
+    if (searchQuery.isNotEmpty) {
+      final lowerQuery = searchQuery.toLowerCase();
       quotes = quotes.where((quote) {
         final customer = appState.customers.firstWhere(
               (c) => c.id == quote.customerId,
@@ -209,18 +211,18 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
   Widget _buildEmptyState(String status) {
     // ... (your existing _buildEmptyState or _buildEmptyStateContent can be adapted)
     // Ensure the buttons in empty state call _navigateToCreateQuoteScreen
-    String title = _searchQuery.isEmpty ? 'No quotes for "$status"' : 'No quotes found';
-    String subtitle = _searchQuery.isEmpty ? 'Create a new quote to see it here.' : 'Try a different search or filter.';
+    String title = searchQuery.isEmpty ? 'No quotes for "$status"' : 'No quotes found';
+    String subtitle = searchQuery.isEmpty ? 'Create a new quote to see it here.' : 'Try a different search or filter.';
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.receipt_long_outlined, size: 64, color: Colors.grey[400]),
-          const SizedBox(height: 16),
-          Text(title, style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.grey[600])),
-          const SizedBox(height: 8),
-          Text(subtitle, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey[500])),
-          if (status == 'All' && _searchQuery.isEmpty) ...[
+          buildEmptyState(
+            icon: Icons.receipt_long_outlined,
+            title: title,
+            subtitle: subtitle,
+          ),
+          if (status == 'All' && searchQuery.isEmpty) ...[
             const SizedBox(height: 24),
             ElevatedButton.icon(
               onPressed: _navigateToCreateQuoteScreen,
@@ -235,15 +237,6 @@ class _QuotesScreenState extends State<QuotesScreen> with TickerProviderStateMix
 
   // _buildStatusBadge, _getLevelColor can remain if used by an adapted QuoteCard
 
-  void _toggleSearch() {
-    setState(() => _showSearch = !_showSearch);
-    if (!_showSearch) _clearSearch();
-  }
-
-  void _clearSearch() {
-    _searchController.clear();
-    setState(() => _searchQuery = '');
-  }
 
   void _navigateToSimplifiedQuoteDetail(SimplifiedMultiLevelQuote quote, Customer customer) {
     Navigator.push(

--- a/lib/widgets/add_custom_field_dialog.dart
+++ b/lib/widgets/add_custom_field_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
+import '../mixins/field_type_mixin.dart';
 
 class AddCustomFieldDialog extends StatefulWidget {
   final List<String> categories;
@@ -19,7 +20,8 @@ class AddCustomFieldDialog extends StatefulWidget {
   State<AddCustomFieldDialog> createState() => _AddCustomFieldDialogState();
 }
 
-class _AddCustomFieldDialogState extends State<AddCustomFieldDialog> {
+class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
+    with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
   final _fieldNameController = TextEditingController();
   final _displayNameController = TextEditingController();
@@ -33,27 +35,6 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog> {
   bool _isLoading = false;
   bool _checkboxValue = false; // Add this for checkbox state
 
-  final List<String> _fieldTypes = [
-    'text',
-    'number',
-    'email',
-    'phone',
-    'multiline',
-    'date',
-    'currency',
-    'checkbox'
-  ];
-
-  final Map<String, String> _fieldTypeNames = {
-    'text': 'Text',
-    'number': 'Number',
-    'email': 'Email',
-    'phone': 'Phone',
-    'multiline': 'Multi-line Text',
-    'date': 'Date',
-    'currency': 'Currency',
-    'checkbox': 'Checkbox',
-  };
 
 
 
@@ -123,10 +104,10 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog> {
                   labelText: 'Field Type *',
                   border: OutlineInputBorder(),
                 ),
-                items: _fieldTypes.map((String fieldType) {
+                items: fieldTypes.map((String fieldType) {
                   return DropdownMenuItem<String>(
                     value: fieldType,
-                    child: Text(_fieldTypeNames[fieldType] ?? fieldType),
+                    child: Text(fieldTypeNames[fieldType] ?? fieldType),
                   );
                 }).toList(),
                 onChanged: (String? newValue) {

--- a/lib/widgets/edit_custom_field_dialog.dart
+++ b/lib/widgets/edit_custom_field_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
+import '../mixins/field_type_mixin.dart';
 
 class EditCustomFieldDialog extends StatefulWidget {
   final CustomAppDataField field;
@@ -21,7 +22,8 @@ class EditCustomFieldDialog extends StatefulWidget {
   State<EditCustomFieldDialog> createState() => _EditCustomFieldDialogState();
 }
 
-class _EditCustomFieldDialogState extends State<EditCustomFieldDialog> {
+class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
+    with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _fieldNameController;
   late final TextEditingController _displayNameController;
@@ -34,27 +36,6 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog> {
   late bool _isRequired;
   bool _isLoading = false;
 
-  final List<String> _fieldTypes = [
-    'text',
-    'number',
-    'email',
-    'phone',
-    'multiline',
-    'date',
-    'currency',
-    'checkbox'
-  ];
-
-  final Map<String, String> _fieldTypeNames = {
-    'text': 'Text',
-    'number': 'Number',
-    'email': 'Email',
-    'phone': 'Phone',
-    'multiline': 'Multi-line Text',
-    'date': 'Date',
-    'currency': 'Currency',
-    'checkbox': 'Checkbox',
-  };
 
   @override
   void initState() {
@@ -128,10 +109,10 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog> {
                   labelText: 'Field Type *',
                   border: OutlineInputBorder(),
                 ),
-                items: _fieldTypes.map((String fieldType) {
+                items: fieldTypes.map((String fieldType) {
                   return DropdownMenuItem<String>(
                     value: fieldType,
-                    child: Text(_fieldTypeNames[fieldType] ?? fieldType),
+                    child: Text(fieldTypeNames[fieldType] ?? fieldType),
                   );
                 }).toList(),
                 onChanged: (String? newValue) {


### PR DESCRIPTION
## Summary
- add new mixins for search widgets, sort menus, empty states and custom field types
- refactor customer, product and quote screens to reuse the new mixins
- simplify custom field dialogs by sharing field type constants

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c248b39c832cb0fe86b290a142b2