### PR TITLE
Fix async context usage

### DIFF
--- a/lib/mixins/communication_actions_mixin.dart
+++ b/lib/mixins/communication_actions_mixin.dart
@@ -16,6 +16,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
       final Uri phoneUri = Uri(scheme: 'tel', path: cleanPhone);
       if (await canLaunchUrl(phoneUri)) {
         await launchUrl(phoneUri);
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Phone app opened'), backgroundColor: Colors.green),
         );
@@ -36,6 +37,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
       );
       if (await canLaunchUrl(emailUri)) {
         await launchUrl(emailUri);
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Email app opened'), backgroundColor: Colors.blue),
         );
@@ -57,6 +59,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
       );
       if (await canLaunchUrl(smsUri)) {
         await launchUrl(smsUri);
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('SMS app opened'), backgroundColor: Colors.purple),
         );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -927,9 +927,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _importData() async {
     try {
       final data = await FileService.instance.pickAndReadBackupFile();
+      if (!mounted) return;
 
       if (data.isNotEmpty) {
-        // Show confirmation dialog
         final confirmed = await showDialog<bool>(
           context: context,
           builder: (context) => AlertDialog(
@@ -943,8 +943,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             content: const Text(
               'This will replace ALL current data with the backup data. '
-                  'Are you sure you want to continue?\n\n'
-                  'This action cannot be undone.',
+              'Are you sure you want to continue?\n\n'
+              'This action cannot be undone.',
             ),
             actions: [
               TextButton(
@@ -962,40 +962,39 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ],
           ),
         );
+        if (!mounted) return;
 
         if (confirmed == true) {
           setState(() => _isProcessing = true);
 
           final databaseService = DatabaseService.instance;
           await databaseService.importAllData(data);
+          if (!mounted) return;
 
-          // Reload app state
           final appState = context.read<AppStateProvider>();
           await appState.loadAllData();
+          if (!mounted) return;
 
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: const Text('Data imported successfully!'),
-                backgroundColor: Colors.green,
-                behavior: SnackBarBehavior.floating,
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-              ),
-            );
-          }
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('Data imported successfully!'),
+              backgroundColor: Colors.green,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            ),
+          );
         }
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Import failed: $e'),
-            backgroundColor: Colors.red,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-          ),
-        );
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Import failed: $e'),
+          backgroundColor: Colors.red,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _isProcessing = false);
     }

--- a/lib/utils/pdf_utils.dart
+++ b/lib/utils/pdf_utils.dart
@@ -38,6 +38,7 @@ class PDFUtils {
         ),
       );
     } catch (e) {
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Error opening PDF: $e'),


### PR DESCRIPTION
## Summary
- avoid using BuildContext across async gaps in `CommunicationActionsMixin`
- add early mounted checks in SettingsScreen `_importData`
- guard against disposed context in PDF utils

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cd4ae900832c8da7e03f8c631b5e