### PR TITLE
Fix async context usage

### DIFF
--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -131,13 +131,16 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 ? 'Are you sure you want to delete this file?'
                 : 'Are you sure you want to delete these ${_selectedMediaIds.length} files?'
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () async {
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               try {
                 final appState = context.read<AppStateProvider>();
                 final mediaItems = appState.getProjectMediaForCustomer(widget.customer.id);
@@ -158,15 +161,15 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 // Exit selection mode
                 _exitSelectionMode();
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text('Deleted ${itemsToDelete.length} file${itemsToDelete.length == 1 ? '' : 's'}'),
                     backgroundColor: Colors.red,
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 showErrorSnackBar('Error deleting files: $e');
               }
             },
@@ -3494,6 +3497,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             ),
             ElevatedButton(
               onPressed: () async {
+                final messenger = ScaffoldMessenger.of(context);
+                final navigator = Navigator.of(context);
+
                 if (contentController.text.trim().isNotEmpty) {
                   final note = InspectionDocumentHelper.createNote(
                     customerId: widget.customer.id,
@@ -3502,9 +3508,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                   );
 
                   await context.read<AppStateProvider>().addInspectionDocument(note);
-                  Navigator.pop(context);
+                  navigator.pop();
 
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     const SnackBar(
                       content: Text('Inspection note saved!'),
                       backgroundColor: Colors.green,
@@ -3575,6 +3581,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             if (!isSmallScreen)
               TextButton(
                 onPressed: () async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  final navigator = Navigator.of(context);
+
                   final shouldDelete = await showDialog<bool>(
                     context: context,
                     builder: (context) => AlertDialog(
@@ -3595,8 +3604,8 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
 
                   if (shouldDelete == true) {
                     await context.read<AppStateProvider>().deleteInspectionDocument(existingNote.id);
-                    Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    navigator.pop();
+                    messenger.showSnackBar(
                       const SnackBar(content: Text('Note deleted'), backgroundColor: Colors.red),
                     );
                   }
@@ -3609,9 +3618,12 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             ),
             ElevatedButton(
               onPressed: () async {
+                final messenger = ScaffoldMessenger.of(context);
+                final navigator = Navigator.of(context);
+
                 existingNote.updateContent(contentController.text.trim());
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   const SnackBar(content: Text('Note updated!'), backgroundColor: Colors.green),
                 );
               },
@@ -3712,9 +3724,12 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
               ),
               ElevatedButton(
                 onPressed: () async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  final navigator = Navigator.of(context);
+
                   final title = titleController.text.trim();
                   if (title.isEmpty) {
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    messenger.showSnackBar(
                       const SnackBar(
                         content: Text('Please enter a title'),
                         backgroundColor: Colors.red,
@@ -3735,9 +3750,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                   // Save to app state
                   await context.read<AppStateProvider>().addInspectionDocument(document);
 
-                  Navigator.pop(context);
+                  navigator.pop();
 
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     const SnackBar(
                       content: Text('PDF document added!'),
                       backgroundColor: Colors.green,
@@ -4532,6 +4547,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
   }
 
   void _deleteMedia(ProjectMedia mediaItem) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -4539,7 +4557,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
         content: Text('Are you sure you want to delete "${mediaItem.fileName}"?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -4554,15 +4572,15 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 // Remove from app state
                 await context.read<AppStateProvider>().deleteProjectMedia(mediaItem.id);
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text('Deleted ${mediaItem.fileName}'),
                     backgroundColor: Colors.red,
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 showErrorSnackBar('Error deleting media: $e');
               }
             },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1073,8 +1073,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           ElevatedButton(
             onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               try {
-                Navigator.pop(context);
+                navigator.pop();
                 setState(() => _isProcessing = true);
 
                 final appState = context.read<AppStateProvider>();
@@ -1085,7 +1088,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 await appState.loadAllData();
 
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(
                       content: const Text('All data cleared successfully'),
                       backgroundColor: Colors.orange,
@@ -1096,7 +1099,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 }
               } catch (e) {
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(
                       content: Text('Error clearing data: $e'),
                       backgroundColor: Colors.red,

--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -2197,18 +2197,21 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               final rateText = taxRateController.text.trim();
               final rate = double.tryParse(rateText);
 
               if (rate == null || rate < 0 || rate > 100) {
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Please enter a valid tax rate (0-100%)'),
                     backgroundColor: Colors.red,
@@ -2230,9 +2233,9 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
                 _updateQuoteLevelsQuantity();
               });
 
-              Navigator.pop(context);
+              navigator.pop();
 
-              ScaffoldMessenger.of(context).showSnackBar(
+              messenger.showSnackBar(
                 SnackBar(
                   content: Text('Tax rate ${rate.toStringAsFixed(2)}% saved and applied'),
                   backgroundColor: Colors.green,

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -193,6 +193,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   void _deleteSelectedPDF() {
     if (_selectedPDFIds.isEmpty) return;
 
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -203,7 +206,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
             : 'Are you sure you want to delete these ${_selectedPDFIds.length} PDF templates?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -217,8 +220,8 @@ class _TemplatesScreenState extends State<TemplatesScreen>
 
                 _exitPDFSelectionMode();
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text(
                         'Deleted ${_selectedPDFIds.length} template${_selectedPDFIds.length == 1 ? '' : 's'}'),
@@ -226,7 +229,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 _showErrorSnackBar('Error deleting templates: $e');
               }
             },
@@ -2100,6 +2103,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showPDFDeleteConfirmation(PDFTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2110,18 +2116,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deletePDFTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Template deleted successfully'),
                     backgroundColor: Colors.green,
@@ -2644,6 +2650,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showMessageDeleteConfirmation(MessageTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2654,18 +2663,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deleteMessageTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Message template deleted successfully'),
                     backgroundColor: Colors.green,
@@ -2823,6 +2832,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showEmailDeleteConfirmation(EmailTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2833,18 +2845,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deleteEmailTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Email template deleted successfully'),
                     backgroundColor: Colors.orange,


### PR DESCRIPTION
## Summary
- avoid using `context` after async gaps

## Testing
- `dart format lib/screens/templates_screen.dart lib/screens/simplified_quote_screen.dart lib/screens/settings_screen.dart lib/screens/customer_detail_screen.dart` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844cee0d6a0832cb426d64fbbaa1c32