### PR TITLE
Fix async context usage

### DIFF
--- a/lib/mixins/communication_actions_mixin.dart
+++ b/lib/mixins/communication_actions_mixin.dart
@@ -11,13 +11,14 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
   }
 
   Future<void> makePhoneCall(String phoneNumber) async {
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final cleanPhone = phoneNumber.replaceAll(RegExp(r'[^\d+]'), '');
       final Uri phoneUri = Uri(scheme: 'tel', path: cleanPhone);
       if (await canLaunchUrl(phoneUri)) {
         await launchUrl(phoneUri);
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(content: Text('Phone app opened'), backgroundColor: Colors.green),
         );
       } else {
@@ -29,6 +30,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
   }
 
   Future<void> sendEmail(String emailAddress, {String? subject, String? body}) async {
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final Uri emailUri = Uri(
         scheme: 'mailto',
@@ -38,7 +40,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
       if (await canLaunchUrl(emailUri)) {
         await launchUrl(emailUri);
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(content: Text('Email app opened'), backgroundColor: Colors.blue),
         );
       } else {
@@ -50,6 +52,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
   }
 
   Future<void> sendSMS(String phoneNumber, {String? message}) async {
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final cleanPhone = phoneNumber.replaceAll(RegExp(r'[^\d+]'), '');
       final Uri smsUri = Uri(
@@ -60,7 +63,7 @@ mixin CommunicationActionsMixin<T extends StatefulWidget> on State<T> {
       if (await canLaunchUrl(smsUri)) {
         await launchUrl(smsUri);
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(content: Text('SMS app opened'), backgroundColor: Colors.purple),
         );
       } else {

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -131,13 +131,16 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 ? 'Are you sure you want to delete this file?'
                 : 'Are you sure you want to delete these ${_selectedMediaIds.length} files?'
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () async {
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               try {
                 final appState = context.read<AppStateProvider>();
                 final mediaItems = appState.getProjectMediaForCustomer(widget.customer.id);
@@ -158,15 +161,15 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 // Exit selection mode
                 _exitSelectionMode();
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text('Deleted ${itemsToDelete.length} file${itemsToDelete.length == 1 ? '' : 's'}'),
                     backgroundColor: Colors.red,
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 showErrorSnackBar('Error deleting files: $e');
               }
             },
@@ -3494,6 +3497,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             ),
             ElevatedButton(
               onPressed: () async {
+                final messenger = ScaffoldMessenger.of(context);
+                final navigator = Navigator.of(context);
+
                 if (contentController.text.trim().isNotEmpty) {
                   final note = InspectionDocumentHelper.createNote(
                     customerId: widget.customer.id,
@@ -3502,9 +3508,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                   );
 
                   await context.read<AppStateProvider>().addInspectionDocument(note);
-                  Navigator.pop(context);
+                  navigator.pop();
 
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     const SnackBar(
                       content: Text('Inspection note saved!'),
                       backgroundColor: Colors.green,
@@ -3575,6 +3581,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             if (!isSmallScreen)
               TextButton(
                 onPressed: () async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  final navigator = Navigator.of(context);
+
                   final shouldDelete = await showDialog<bool>(
                     context: context,
                     builder: (context) => AlertDialog(
@@ -3595,8 +3604,8 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
 
                   if (shouldDelete == true) {
                     await context.read<AppStateProvider>().deleteInspectionDocument(existingNote.id);
-                    Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    navigator.pop();
+                    messenger.showSnackBar(
                       const SnackBar(content: Text('Note deleted'), backgroundColor: Colors.red),
                     );
                   }
@@ -3609,9 +3618,12 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
             ),
             ElevatedButton(
               onPressed: () async {
+                final messenger = ScaffoldMessenger.of(context);
+                final navigator = Navigator.of(context);
+
                 existingNote.updateContent(contentController.text.trim());
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   const SnackBar(content: Text('Note updated!'), backgroundColor: Colors.green),
                 );
               },
@@ -3712,9 +3724,12 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
               ),
               ElevatedButton(
                 onPressed: () async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  final navigator = Navigator.of(context);
+
                   final title = titleController.text.trim();
                   if (title.isEmpty) {
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    messenger.showSnackBar(
                       const SnackBar(
                         content: Text('Please enter a title'),
                         backgroundColor: Colors.red,
@@ -3735,9 +3750,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                   // Save to app state
                   await context.read<AppStateProvider>().addInspectionDocument(document);
 
-                  Navigator.pop(context);
+                  navigator.pop();
 
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     const SnackBar(
                       content: Text('PDF document added!'),
                       backgroundColor: Colors.green,
@@ -4156,6 +4171,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
 
     if (selectedCategory == null) return; // User cancelled
 
+    final messenger = ScaffoldMessenger.of(context);
     setState(() => _isProcessingMedia = true);
 
     try {
@@ -4191,7 +4207,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       }
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           SnackBar(
             content: Text('Added $successCount of ${files.length} files'),
             backgroundColor: successCount == files.length ? Colors.green : Colors.orange,
@@ -4367,6 +4383,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       }
 
       // Show media details dialog
+      final messenger = ScaffoldMessenger.of(context);
       final ProjectMedia? mediaItem = await showDialog<ProjectMedia>(
         context: context,
         barrierDismissible: false,
@@ -4384,7 +4401,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
         await context.read<AppStateProvider>().addProjectMedia(mediaItem);
 
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
+          messenger.showSnackBar(
             SnackBar(
               content: Text('Added ${mediaItem.fileName}'),
               backgroundColor: Colors.green,
@@ -4519,8 +4536,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       builder: (context) => MediaDetailsDialog.edit(
         mediaItem: mediaItem,
         onSave: (updatedMedia) async {
+          final messenger = ScaffoldMessenger.of(context);
           await context.read<AppStateProvider>().updateProjectMedia(updatedMedia);
-          ScaffoldMessenger.of(context).showSnackBar(
+          messenger.showSnackBar(
             const SnackBar(
               content: Text('Media details updated'),
               backgroundColor: Colors.green,
@@ -4532,6 +4550,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
   }
 
   void _deleteMedia(ProjectMedia mediaItem) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -4539,7 +4560,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
         content: Text('Are you sure you want to delete "${mediaItem.fileName}"?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -4554,15 +4575,15 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 // Remove from app state
                 await context.read<AppStateProvider>().deleteProjectMedia(mediaItem.id);
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text('Deleted ${mediaItem.fileName}'),
                     backgroundColor: Colors.red,
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 showErrorSnackBar('Error deleting media: $e');
               }
             },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1073,8 +1073,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           ElevatedButton(
             onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               try {
-                Navigator.pop(context);
+                navigator.pop();
                 setState(() => _isProcessing = true);
 
                 final appState = context.read<AppStateProvider>();
@@ -1085,7 +1088,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 await appState.loadAllData();
 
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(
                       content: const Text('All data cleared successfully'),
                       backgroundColor: Colors.orange,
@@ -1096,7 +1099,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 }
               } catch (e) {
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(
                       content: Text('Error clearing data: $e'),
                       backgroundColor: Colors.red,
@@ -1349,6 +1352,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _selectCompanyLogo(StateSetter setDialogState, AppSettings settings, AppStateProvider appState) async {
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final newPath = await FileService.instance.pickAndSaveCompanyLogo();
 
@@ -1358,18 +1362,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         setDialogState(() {});
 
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           SnackBar(
             content: const Text('Company logo updated!'),
             backgroundColor: Colors.green,
             behavior: SnackBarBehavior.floating,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
         );
       }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Error selecting logo: $e'),
           backgroundColor: Colors.red,

--- a/lib/screens/simplified_quote_detail_screen.dart
+++ b/lib/screens/simplified_quote_detail_screen.dart
@@ -590,6 +590,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
     );
   }
   void _previewPdf() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     try {
       final appState = context.read<AppStateProvider>();
 
@@ -603,7 +605,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
 
       if (existingPdf.isEmpty) {
         // No existing PDF found
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(
             content: Text('No saved PDF found. Use "Generate PDF" to create one first.'),
             backgroundColor: Colors.orange,
@@ -618,7 +620,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       // Check if file still exists
       final file = File(latestPdf.filePath);
       if (!await file.exists()) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           SnackBar(
             content: Text('PDF file not found: ${latestPdf.fileName}'),
             backgroundColor: Colors.red,
@@ -628,8 +630,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       }
 
       // Open existing PDF in preview screen
-      Navigator.push(
-        context,
+      navigator.push(
         MaterialPageRoute(
           builder: (context) => PdfPreviewScreen(
             pdfPath: latestPdf.filePath,
@@ -643,7 +644,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       );
 
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Error opening PDF: $e'),
           backgroundColor: Colors.red,
@@ -737,6 +738,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
 // REPLACE the _generatePdf method with this fixed version:
 
   void _generatePdf() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     try {
       final appState = context.read<AppStateProvider>();
 
@@ -805,11 +808,10 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
         );
       }
 
-      Navigator.pop(context); // Close loading dialog
+      navigator.pop(); // Close loading dialog
 
       // 🚀 NEW: Navigate to PDF Preview Screen
-      final result = await Navigator.push<bool>(
-        context,
+      final result = await navigator.push<bool>(
         MaterialPageRoute(
           builder: (context) => PdfPreviewScreen(
             pdfPath: pdfPath,
@@ -826,7 +828,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       // Handle result from preview screen
       if (result == true) {
         // PDF was saved successfully
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(
             content: Row(
               children: [
@@ -841,7 +843,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
         );
       } else if (result == false) {
         // PDF was discarded
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           const SnackBar(
             content: Row(
               children: [
@@ -859,8 +861,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
 
     } catch (e) {
       debugPrint('❌ Error generating PDF: $e');
-      Navigator.pop(context); // Close loading dialog if open
-      ScaffoldMessenger.of(context).showSnackBar(
+      navigator.pop(); // Close loading dialog if open
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Error generating PDF: $e'),
           backgroundColor: Colors.red,
@@ -1011,9 +1013,11 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
 
 
   void _previewTemplateInDialog(PDFTemplate template) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     try {
       // Close the selection dialog first
-      Navigator.pop(context);
+      navigator.pop();
 
       // Show loading
       showDialog(
@@ -1039,9 +1043,9 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
         customData: {'preview': 'true', 'watermark': 'PREVIEW'},
       );
 
-      Navigator.pop(context); // Close loading
+      navigator.pop(); // Close loading
 
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Preview generated: ${previewPath.split('/').last}'),
           action: SnackBarAction(
@@ -1062,8 +1066,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
         _showTemplateSelectionDialog(templates);
       }
     } catch (e) {
-      Navigator.pop(context); // Close loading if open
-      ScaffoldMessenger.of(context).showSnackBar(
+      navigator.pop(); // Close loading if open
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Error generating preview: $e'),
           backgroundColor: Colors.red,

--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -2197,18 +2197,21 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              final navigator = Navigator.of(context);
+
               final rateText = taxRateController.text.trim();
               final rate = double.tryParse(rateText);
 
               if (rate == null || rate < 0 || rate > 100) {
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Please enter a valid tax rate (0-100%)'),
                     backgroundColor: Colors.red,
@@ -2230,9 +2233,9 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
                 _updateQuoteLevelsQuantity();
               });
 
-              Navigator.pop(context);
+              navigator.pop();
 
-              ScaffoldMessenger.of(context).showSnackBar(
+              messenger.showSnackBar(
                 SnackBar(
                   content: Text('Tax rate ${rate.toStringAsFixed(2)}% saved and applied'),
                   backgroundColor: Colors.green,

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -724,6 +724,8 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   }
 
   Future<void> _uploadAndCreateTemplate() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final appState = context.read<AppStateProvider>();
     try {
       final result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
@@ -747,7 +749,6 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
 
         if (!mounted) return;
         if (template != null) {
-          final appState = context.read<AppStateProvider>();
           await appState.addExistingPDFTemplateToList(template);
 
           setState(() {
@@ -755,7 +756,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
             _loadTemplateDetails();
           });
 
-          ScaffoldMessenger.of(context).showSnackBar(
+          messenger.showSnackBar(
             const SnackBar(
               content: Text('Template created!'),
               backgroundColor: Colors.green,
@@ -763,7 +764,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
             ),
           );
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
+          messenger.showSnackBar(
             const SnackBar(
               content: Text('Failed to create template.'),
               backgroundColor: Colors.red,
@@ -774,7 +775,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
     } catch (e) {
       _setLoading(false);
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Text('Error: $e'),
           backgroundColor: Colors.red,
@@ -797,26 +798,28 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       debugPrint('📍 Field mappings: ${_currentTemplate!.fieldMappings.length}');
     }
 
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final appState = context.read<AppStateProvider>();
     try {
       _currentTemplate!.updatedAt = DateTime.now();
       _currentTemplate!.userCategoryKey = _selectedCategoryKey;
-      final appState = context.read<AppStateProvider>();
       await appState.updatePDFTemplate(_currentTemplate!);
 
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('Template saved!'),
           backgroundColor: Colors.green,
           duration: Duration(seconds: 1),
         ),
       );
-      Navigator.pop(context);
+      navigator.pop();
 
     } catch (e) {
       if (kDebugMode) debugPrint('❌ Error saving template: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messenger.showSnackBar(
           SnackBar(content: Text('Save failed: $e'), backgroundColor: Colors.red),
         );
       }
@@ -826,6 +829,8 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   void _previewTemplate() async {
     if (_currentTemplate == null) return;
     _setLoading(true, 'Generating preview...');
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     try {
       final previewPath = await TemplateService.instance.generateTemplatePreview(_currentTemplate!);
       _setLoading(false);
@@ -833,8 +838,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       if (!mounted) return;
 
       // Navigate to PdfPreviewScreen like templates_screen does
-      Navigator.push(
-        context,
+      navigator.push(
         MaterialPageRoute(
           builder: (context) => PdfPreviewScreen(
             pdfPath: previewPath,
@@ -848,7 +852,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
     } catch (e) {
       _setLoading(false);
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(content: Text('Error generating preview: $e'), backgroundColor: Colors.red),
       );
     }

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -193,6 +193,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   void _deleteSelectedPDF() {
     if (_selectedPDFIds.isEmpty) return;
 
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -203,7 +206,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
             : 'Are you sure you want to delete these ${_selectedPDFIds.length} PDF templates?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -217,8 +220,8 @@ class _TemplatesScreenState extends State<TemplatesScreen>
 
                 _exitPDFSelectionMode();
 
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
+                navigator.pop();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text(
                         'Deleted ${_selectedPDFIds.length} template${_selectedPDFIds.length == 1 ? '' : 's'}'),
@@ -226,7 +229,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                   ),
                 );
               } catch (e) {
-                Navigator.pop(context);
+                navigator.pop();
                 _showErrorSnackBar('Error deleting templates: $e');
               }
             },
@@ -1962,6 +1965,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _previewPDFTemplate(PDFTemplate template) async {
+    final navigator = Navigator.of(context);
     try {
       showDialog(
         context: context,
@@ -1980,10 +1984,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
       final previewPath =
           await TemplateService.instance.generateTemplatePreview(template);
 
-      Navigator.pop(context); // Close loading dialog
+      navigator.pop(); // Close loading dialog
 
-      Navigator.push(
-        context,
+      navigator.push(
         MaterialPageRoute(
           builder: (context) => PdfPreviewScreen(
             pdfPath: previewPath,
@@ -1994,7 +1997,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
       );
     } catch (e) {
-      Navigator.pop(context); // Close loading dialog
+      navigator.pop(); // Close loading dialog
       _showErrorSnackBar('Error generating preview: $e');
     }
   }
@@ -2100,6 +2103,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showPDFDeleteConfirmation(PDFTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2110,18 +2116,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deletePDFTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Template deleted successfully'),
                     backgroundColor: Colors.green,
@@ -2644,6 +2650,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showMessageDeleteConfirmation(MessageTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2654,18 +2663,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deleteMessageTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Message template deleted successfully'),
                     backgroundColor: Colors.green,
@@ -2823,6 +2832,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _showEmailDeleteConfirmation(EmailTemplate template) {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -2833,18 +2845,18 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => navigator.pop(),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
-              Navigator.pop(context);
+              navigator.pop();
 
               try {
                 await context
                     .read<AppStateProvider>()
                     .deleteEmailTemplate(template.id);
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   const SnackBar(
                     content: Text('Email template deleted successfully'),
                     backgroundColor: Colors.orange,


### PR DESCRIPTION
## Summary
- avoid using `context` after async gaps by capturing messenger and navigator before awaiting
- fix context usage in settings, template editor, templates, customer detail, and quote detail screens
- update communication mixin to capture messenger before awaits

## Testing
- `dart format lib/screens/settings_screen.dart lib/screens/template_editor_screen.dart lib/screens/templates_screen.dart lib/screens/customer_detail_screen.dart lib/screens/simplified_quote_detail_screen.dart lib/mixins/communication_actions_mixin.dart lib/mixins/file_sharing_mixin.dart` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844cee0d6a0832cb426d64fbbaa1c32