### PR TITLE
Fix context use after async gaps

### DIFF
--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -3602,10 +3602,11 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                     ),
                     );
 
-                    if (!mounted) return;
+                    if (!context.mounted) return;
 
                     if (shouldDelete == true) {
                       await context.read<AppStateProvider>().deleteInspectionDocument(existingNote.id);
+                      if (!context.mounted) return;
                       navigator.pop();
                       messenger.showSnackBar(
                       const SnackBar(content: Text('Note deleted'), backgroundColor: Colors.red),
@@ -4587,8 +4588,9 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 }
 
                 // Remove from app state
-                if (!mounted) return;
+                if (!context.mounted) return;
                 await context.read<AppStateProvider>().deleteProjectMedia(mediaItem.id);
+                if (!context.mounted) return;
 
                 navigator.pop();
                 messenger.showSnackBar(


### PR DESCRIPTION
## Summary
- fix lint by checking `context.mounted` around async calls in `CustomerDetailScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844db59a660832c89bfb6a0a61eb1d8