### PR TITLE
Centralize UI color theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'providers/template_provider.dart';
 import 'services/database_service.dart';
 import 'models/email_template.dart';
 import 'models/inspection_document.dart';
+import 'theme/rufko_theme.dart';
 // Your Screens
 import 'screens/home_screen.dart';
 import 'models/template_category.dart';
@@ -90,39 +91,7 @@ class RufkoApp extends StatelessWidget {
     return MaterialApp(
       title: 'Rufko - Professional Roofing Estimator',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF1565C0)),
-        useMaterial3: true,
-        primaryColor: const Color(0xFF1565C0),
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFF1565C0),
-          foregroundColor: Colors.white,
-          elevation: 2,
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF1565C0),
-            foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-          ),
-        ),
-        cardTheme: CardThemeData(
-          elevation: 2,
-          margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-        inputDecorationTheme: InputDecorationTheme(
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-        ),
-      ),
+      theme: RufkoTheme.phoneTheme,
       home: const HomeScreen(),
     );
   }

--- a/lib/mixins/file_sharing_mixin.dart
+++ b/lib/mixins/file_sharing_mixin.dart
@@ -6,6 +6,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:file_picker/file_picker.dart';
 import '../models/customer.dart';
 import '../utils/common_utils.dart';
+import '../theme/rufko_theme.dart';
 
 mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
   bool _isSharing = false;
@@ -107,7 +108,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                   Icon(
                     getFileIcon(fileType ?? _getFileTypeFromExtension(fileName)),
                     size: 24,
-                    color: const Color(0xFF2E86AB),
+                    color: RufkoTheme.primaryColor,
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -272,7 +273,7 @@ mixin FileSharingMixin<T extends StatefulWidget> on State<T> {
                     style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
                   ),
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF2E86AB),
+                    backgroundColor: RufkoTheme.primaryColor,
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/app_state_provider.dart';
+import '../theme/rufko_theme.dart';
 
 class CategoryManagementScreen extends StatefulWidget {
   const CategoryManagementScreen({super.key});
@@ -34,7 +35,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
       backgroundColor: Colors.grey[50],
       appBar: AppBar(
         title: const Text('Category Management'),
-        backgroundColor: const Color(0xFF2E86AB),
+        backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         elevation: 0,
         bottom: TabBar(
@@ -76,7 +77,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
               color: Colors.white,
               child: Row(
                 children: [
-                  Icon(Icons.category, color: const Color(0xFF2E86AB)),
+                  Icon(Icons.category, color: RufkoTheme.primaryColor),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -89,7 +90,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
                     icon: const Icon(Icons.add, size: 18),
                     label: const Text('Add Category'),
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFF2E86AB),
+                      backgroundColor: RufkoTheme.primaryColor,
                       foregroundColor: Colors.white,
                     ),
                   ),
@@ -305,7 +306,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
 
   Color _getCategoryColor(String templateType) {
     switch (templateType) {
-      case 'PDF Templates': return const Color(0xFF2E86AB);
+      case 'PDF Templates': return RufkoTheme.primaryColor;
       case 'Message Templates': return Colors.green;
       case 'Email Templates': return Colors.orange;
       case 'Custom Fields': return Colors.purple;
@@ -387,7 +388,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
               }
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
             ),
             child: const Text('Add Category'),
@@ -460,7 +461,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
               }
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
             ),
             child: const Text('Save Changes'),

--- a/lib/screens/custom_app_data_screen.dart
+++ b/lib/screens/custom_app_data_screen.dart
@@ -8,6 +8,7 @@ import '../providers/app_state_provider.dart';
 import '../widgets/add_custom_field_dialog.dart';
 import '../widgets/edit_custom_field_dialog.dart';
 import '../utils/common_utils.dart';
+import '../theme/rufko_theme.dart';
 
 class CustomAppDataScreen extends StatefulWidget {
   const CustomAppDataScreen({super.key});
@@ -38,7 +39,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
       backgroundColor: Colors.grey[50],
       appBar: AppBar(
         title: const Text('Custom App Data'),
-        backgroundColor: const Color(0xFF2E86AB),
+        backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         elevation: 0,
         actions: [
@@ -52,7 +53,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
       body: _buildManageFieldsTab(),
       floatingActionButton: FloatingActionButton(
         onPressed: _showAddFieldDialog,
-        backgroundColor: const Color(0xFF2E86AB),
+        backgroundColor: RufkoTheme.primaryColor,
         child: const Icon(Icons.add, color: Colors.white),
       ),
     );
@@ -246,7 +247,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                           icon: const Icon(Icons.checklist, size: 18),
                           label: const Text('Select'),
                           style: ElevatedButton.styleFrom(
-                            backgroundColor: const Color(0xFF2E86AB),
+                            backgroundColor: RufkoTheme.primaryColor,
                             foregroundColor: Colors.white,
                             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                           ),
@@ -356,7 +357,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
           ],
         ),
         selected: isSelected,
-        selectedColor: const Color(0xFF2E86AB),
+        selectedColor: RufkoTheme.primaryColor,
         labelStyle: TextStyle(
           color: isSelected ? Colors.white : Colors.grey[700],
           fontSize: 12,
@@ -399,7 +400,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: const Color(0xFF2E86AB).withValues(alpha: 0.1),
+                  color: RufkoTheme.primaryColor.withValues(alpha: 0.1),
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(8),
                     topRight: Radius.circular(8),
@@ -409,7 +410,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                   children: [
                     Icon(
                       _getCategoryIcon(category),
-                      color: const Color(0xFF2E86AB),
+                      color: RufkoTheme.primaryColor,
                       size: 20,
                     ),
                     const SizedBox(width: 8),
@@ -417,7 +418,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                       categoryDisplayName,
                       style: const TextStyle(
                         fontWeight: FontWeight.bold,
-                        color: Color(0xFF2E86AB),
+                        color: RufkoTheme.primaryColor,
                       ),
                     ),
                     const Spacer(),
@@ -449,7 +450,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
         children: [
           Card(
             elevation: isSelected ? 3 : 1,
-            color: isSelected ? const Color(0xFF2E86AB).withValues(alpha: 0.1) : null,
+            color: isSelected ? RufkoTheme.primaryColor.withValues(alpha: 0.1) : null,
             child: InkWell(
               onTap: _isFieldSelectionMode
                   ? () => _toggleFieldSelection(field.id)
@@ -459,7 +460,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                 decoration: isSelected
                     ? BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: const Color(0xFF2E86AB), width: 2),
+                  border: Border.all(color: RufkoTheme.primaryColor, width: 2),
                 )
                     : null,
                 child: ListTile(
@@ -475,7 +476,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                     field.displayName,
                     style: TextStyle(
                       fontWeight: FontWeight.w500,
-                      color: isSelected ? const Color(0xFF2E86AB) : null,
+                      color: isSelected ? RufkoTheme.primaryColor : null,
                     ),
                   ),
                   subtitle: Column(
@@ -485,7 +486,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                         'Field: ${field.fieldName} • Type: ${field.fieldType}',
                         style: TextStyle(
                           color: isSelected
-                              ? const Color(0xFF2E86AB).withValues(alpha: 0.7)
+                              ? RufkoTheme.primaryColor.withValues(alpha: 0.7)
                               : Colors.grey[600],
                           fontSize: 12,
                         ),
@@ -496,7 +497,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                           decoration: BoxDecoration(
                             color: isSelected
-                                ? const Color(0xFF2E86AB).withValues(alpha: 0.2)
+                                ? RufkoTheme.primaryColor.withValues(alpha: 0.2)
                                 : Colors.grey[200],
                             borderRadius: BorderRadius.circular(12),
                           ),
@@ -562,7 +563,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
                   onChanged: (bool? value) => _toggleFieldSelection(field.id),
                   materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   visualDensity: VisualDensity.compact,
-                  activeColor: const Color(0xFF2E86AB),
+                  activeColor: RufkoTheme.primaryColor,
                 ),
               ),
             ),
@@ -602,7 +603,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> {
             icon: const Icon(Icons.add),
             label: const Text('Add First Field'),
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
             ),
           ),

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -13,6 +13,7 @@ import '../models/customer.dart';
 import '../models/project_media.dart';
 import '../models/simplified_quote.dart';
 import '../providers/app_state_provider.dart';
+import '../theme/rufko_theme.dart';
 import 'pdf_preview_screen.dart';
 import 'simplified_quote_screen.dart';
 import 'simplified_quote_detail_screen.dart';
@@ -330,7 +331,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
       expandedHeight: 100,
       floating: false,
       pinned: true,
-      backgroundColor: const Color(0xFF2E86AB),
+      backgroundColor: RufkoTheme.primaryColor,
       foregroundColor: Colors.white,
       elevation: 0,
       flexibleSpace: FlexibleSpaceBar(
@@ -340,8 +341,8 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
               colors: [
-                Color(0xFF2E86AB),
-                Color(0xFF1B5E7F),
+                RufkoTheme.primaryColor,
+                RufkoTheme.primaryDarkColor,
               ],
             ),
           ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import '../providers/app_state_provider.dart';
 import '../models/customer.dart';
 import '../models/simplified_quote.dart';
+import '../theme/rufko_theme.dart';
 
 import 'customers_screen.dart';
 import 'quotes_screen.dart';
@@ -103,7 +104,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
           currentIndex: _selectedIndex,
           onTap: _onNavItemTapped,
           items: _navItems,
-          selectedItemColor: const Color(0xFF2E86AB), // Blue from logo
+          selectedItemColor: RufkoTheme.primaryColor, // Blue from logo
           unselectedItemColor: Colors.grey[600],
           backgroundColor: Colors.transparent,
           elevation: 0,
@@ -167,8 +168,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
               colors: [
-                const Color(0xFF2E86AB), // Blue from your roof
-                const Color(0xFF1B5E7F), // Darker blue
+                RufkoTheme.primaryColor, // Blue from your roof
+                RufkoTheme.primaryDarkColor, // Darker blue
               ],
             ),
           ),
@@ -205,7 +206,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                                     color: Colors.white,
                                     borderRadius: BorderRadius.circular(20),
                                   ),
-                                  child: const Icon(Icons.roofing, color: Color(0xFF2E86AB), size: 60),
+                                  child: const Icon(Icons.roofing, color: RufkoTheme.primaryColor, size: 60),
                                 );
                               },
                             ),
@@ -478,12 +479,12 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   Widget _buildCustomerListItem(Customer customer, int quoteCount) {
     return ListTile(
       leading: CircleAvatar(
-        backgroundColor: const Color(0xFF2E86AB).withValues(alpha: 0.1),
+        backgroundColor: RufkoTheme.primaryColor.withValues(alpha: 0.1),
         child: Text(
           customer.name.isNotEmpty ? customer.name[0].toUpperCase() : 'C',
           style: const TextStyle(
             fontWeight: FontWeight.bold,
-            color: Color(0xFF2E86AB),
+            color: RufkoTheme.primaryColor,
           ),
         ),
       ),
@@ -773,7 +774,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   Widget _buildFloatingActionButton() {
     return FloatingActionButton.extended(
       onPressed: _showQuickCreateDialog,
-      backgroundColor: const Color(0xFF2E86AB),
+      backgroundColor: RufkoTheme.primaryColor,
       foregroundColor: Colors.white,
       icon: const Icon(Icons.add),
       label: const Text('Quick Create'),

--- a/lib/screens/pdf_preview_screen.dart
+++ b/lib/screens/pdf_preview_screen.dart
@@ -13,6 +13,7 @@ import '../providers/app_state_provider.dart';
 import '../models/simplified_quote.dart';
 import '../models/customer.dart';
 import '../models/project_media.dart';
+import '../theme/rufko_theme.dart';
 import 'package:intl/intl.dart';
 import '../mixins/file_sharing_mixin.dart';
 // Model for form fields
@@ -461,7 +462,7 @@ class _PdfPreviewScreenState extends State<PdfPreviewScreen>
             ),
           ],
         ),
-        backgroundColor: const Color(0xFF2E86AB),
+        backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         elevation: 0,
         actions: [

--- a/lib/screens/simplified_quote_detail_screen.dart
+++ b/lib/screens/simplified_quote_detail_screen.dart
@@ -11,6 +11,7 @@ import '../providers/app_state_provider.dart';
 import '../models/pdf_template.dart';
 import 'pdf_preview_screen.dart';
 import 'simplified_quote_screen.dart';
+import '../theme/rufko_theme.dart';
 
 class SimplifiedQuoteDetailScreen extends StatefulWidget {
   final SimplifiedMultiLevelQuote quote;
@@ -48,7 +49,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
               expandedHeight: 100,
               floating: false,
               pinned: true,
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
               elevation: 0,
               flexibleSpace: FlexibleSpaceBar(
@@ -58,8 +59,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                       colors: [
-                        Color(0xFF2E86AB),
-                        Color(0xFF1B5E7F),
+                        RufkoTheme.primaryColor,
+                        RufkoTheme.primaryDarkColor,
                       ],
                     ),
                   ),
@@ -1176,7 +1177,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
             Container(
               padding: const EdgeInsets.all(20),
               decoration: const BoxDecoration(
-                color: Color(0xFF2E86AB),
+                color: RufkoTheme.primaryColor,
                 borderRadius: BorderRadius.only(
                   topLeft: Radius.circular(16),
                   topRight: Radius.circular(16),
@@ -1350,7 +1351,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                     child: ElevatedButton(
                       onPressed: _addDiscount,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF2E86AB),
+                        backgroundColor: RufkoTheme.primaryColor,
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(vertical: 14),
                       ),

--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -13,6 +13,7 @@ import 'simplified_quote_detail_screen.dart';
 import '../services/tax_service.dart';
 import '../models/quote_extras.dart'; // NEW: For PermitItem and CustomLineItem
 import 'package:rufko/screens/inspection_viewer_screen.dart';
+import '../theme/rufko_theme.dart';
 
 class SimplifiedQuoteScreen extends StatefulWidget {
   final Customer customer;
@@ -85,7 +86,7 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
               expandedHeight: 100,
               floating: false,
               pinned: true,
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
               elevation: 0,
               flexibleSpace: FlexibleSpaceBar(
@@ -95,8 +96,8 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                       colors: [
-                        Color(0xFF2E86AB),
-                        Color(0xFF1B5E7F),
+                        RufkoTheme.primaryColor,
+                        RufkoTheme.primaryDarkColor,
                       ],
                     ),
                   ),

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -11,6 +11,7 @@ import '../models/pdf_template.dart';
 import '../services/template_service.dart';
 import '../providers/app_state_provider.dart';
 import 'pdf_preview_screen.dart';
+import '../theme/rufko_theme.dart';
 
 class TemplateEditorScreen extends StatefulWidget {
   const TemplateEditorScreen({
@@ -117,7 +118,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
         title: Text(_currentTemplate == null
             ? 'Create New Template'
             : 'Edit: ${_currentTemplate?.templateName ?? "Template"}'),
-        backgroundColor: const Color(0xFF2E86AB),
+        backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         actions: [
           if (_currentTemplate != null)
@@ -465,7 +466,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
           child: Scaffold(
             appBar: AppBar(
               title: Text('Map: $pdfFieldName'),
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
               foregroundColor: Colors.white,
               leading: IconButton(
                 icon: const Icon(Icons.close),

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -10,6 +10,7 @@ import '../services/template_service.dart';
 import 'template_editor_screen.dart';
 import 'pdf_preview_screen.dart';
 import 'custom_app_data_screen.dart';
+import '../theme/rufko_theme.dart';
 import 'message_template_editor_screen.dart';
 import 'email_template_editor_screen.dart';
 import '../models/email_template.dart';
@@ -290,7 +291,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
       expandedHeight: 100,
       floating: false,
       pinned: true,
-      backgroundColor: const Color(0xFF2E86AB),
+      backgroundColor: RufkoTheme.primaryColor,
       foregroundColor: Colors.white,
       elevation: 0,
       flexibleSpace: FlexibleSpaceBar(
@@ -300,8 +301,8 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
               colors: [
-                Color(0xFF2E86AB),
-                Color(0xFF1B5E7F),
+                RufkoTheme.primaryColor,
+                RufkoTheme.primaryDarkColor,
               ],
             ),
           ),
@@ -389,7 +390,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               onPressed: _createNewPDFTemplate,
               icon: const Icon(Icons.add),
               label: const Text('New PDF Template'),
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
             );
           case 1: // Message Templates tab
             return FloatingActionButton.extended(
@@ -413,7 +414,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               onPressed: _createNewCustomField,
               icon: const Icon(Icons.add),
               label: const Text('New Custom Field'),
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
             );
           default:
             return FloatingActionButton.extended(
@@ -421,7 +422,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               onPressed: _createNewPDFTemplate,
               icon: const Icon(Icons.add),
               label: const Text('New Template'),
-              backgroundColor: const Color(0xFF2E86AB),
+              backgroundColor: RufkoTheme.primaryColor,
             );
         }
       },
@@ -639,7 +640,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
           ],
         ),
         selected: isSelected,
-        selectedColor: const Color(0xFF2E86AB),
+        selectedColor: RufkoTheme.primaryColor,
         labelStyle: TextStyle(
           color: isSelected ? Colors.white : Colors.grey[700],
           fontSize: 12,

--- a/lib/theme/rufko_theme.dart
+++ b/lib/theme/rufko_theme.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// Central place for Rufko UI settings.
+/// In the future, more variations (desktop, phone) can be added here.
+mixin RufkoTheme {
+  static const Color primaryColor = Color(0xFF2E86AB);
+  static const Color primaryDarkColor = Color(0xFF1B5E7F);
+
+  static ThemeData get phoneTheme => _baseTheme();
+  static ThemeData get desktopTheme => _baseTheme();
+
+  static ThemeData _baseTheme() {
+    return ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: primaryColor),
+      useMaterial3: true,
+      primaryColor: primaryColor,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: primaryColor,
+        foregroundColor: Colors.white,
+        elevation: 2,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: primaryColor,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+      cardTheme: CardTheme(
+        elevation: 2,
+        margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      ),
+    );
+  }
+}

--- a/lib/widgets/add_custom_field_dialog.dart
+++ b/lib/widgets/add_custom_field_dialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
 import '../mixins/field_type_mixin.dart';
+import '../theme/rufko_theme.dart';
 
 class AddCustomFieldDialog extends StatefulWidget {
   final List<String> categories;
@@ -257,7 +258,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
         ElevatedButton(
           onPressed: _isLoading ? null : _handleAddField,
           style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF2E86AB),
+            backgroundColor: RufkoTheme.primaryColor,
             foregroundColor: Colors.white,
           ),
           child: _isLoading

--- a/lib/widgets/edit_custom_field_dialog.dart
+++ b/lib/widgets/edit_custom_field_dialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../models/custom_app_data.dart';
 import '../providers/app_state_provider.dart';
 import '../mixins/field_type_mixin.dart';
+import '../theme/rufko_theme.dart';
 
 class EditCustomFieldDialog extends StatefulWidget {
   final CustomAppDataField field;
@@ -234,7 +235,7 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
         ElevatedButton(
           onPressed: _isLoading ? null : _handleSaveChanges,
           style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF2E86AB),
+            backgroundColor: RufkoTheme.primaryColor,
             foregroundColor: Colors.white,
           ),
           child: _isLoading


### PR DESCRIPTION
## Summary
- add `RufkoTheme` mixin with app color palette
- hook new theme into `MaterialApp`
- use theme colors across UI files

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dd0225dc832ca374553e6a190de7