### PR TITLE
Improve separation of UI and logic

### DIFF
--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -14,6 +14,8 @@ import '../models/custom_app_data.dart';
 import '../services/database_service.dart';
 import '../services/pdf_service.dart';
 import '../services/template_service.dart';
+import '../services/file_service.dart';
+import '../services/tax_service.dart';
 import '../models/message_template.dart';
 import '../models/email_template.dart';
 import '../models/template_category.dart';
@@ -1273,6 +1275,30 @@ class AppStateProvider extends ChangeNotifier {
     return invalidTemplates;
   }
 
+  Future<PDFTemplate?> createPDFTemplateFromFile(
+      String pdfPath, String templateName) async {
+    try {
+      setLoading(true, 'Processing PDF & Detecting Fields...');
+      final template =
+          await TemplateService.instance.createTemplateFromPDF(pdfPath, templateName);
+      if (template != null) {
+        await addExistingPDFTemplateToList(template);
+      }
+      return template;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<String> generateTemplatePreview(PDFTemplate template) async {
+    try {
+      setLoading(true, 'Generating preview...');
+      return await TemplateService.instance.generateTemplatePreview(template);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   Future<void> addExistingPDFTemplateToList(PDFTemplate template) async {
     try {
       final existingIndex = _pdfTemplates.indexWhere((t) => t.id == template.id);
@@ -1793,6 +1819,70 @@ class AppStateProvider extends ChangeNotifier {
   Future<int> getCategoryUsageCount(String templateType, String categoryKey) async {
     return await _db.getCategoryUsageCount(templateType, categoryKey);
   }
+
+  // --- Data Management ---
+  Future<String> exportAllDataToFile() async {
+    try {
+      setLoading(true, 'Exporting data...');
+      final data = await _db.exportAllData();
+      final filePath = await FileService.instance.saveExportedData(data);
+      return filePath;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<Map<String, dynamic>> pickBackupData() async {
+    return await FileService.instance.pickAndReadBackupFile();
+  }
+
+  Future<String?> pickAndSaveCompanyLogo(AppSettings settings) async {
+    final newPath = await FileService.instance.pickAndSaveCompanyLogo();
+    if (newPath != null) {
+      settings.updateCompanyLogo(newPath);
+      await updateAppSettings(settings);
+    }
+    return newPath;
+  }
+
+  Future<void> removeCompanyLogo(AppSettings settings) async {
+    settings.updateCompanyLogo(null);
+    await updateAppSettings(settings);
+  }
+
+  Future<void> importAllDataFromFile(Map<String, dynamic> data) async {
+    try {
+      setLoading(true, 'Importing data...');
+      await _db.importAllData(data);
+      await loadAllData();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<void> clearAllData() async {
+    await importAllDataFromFile({});
+  }
+
+  // --- Tax Helpers ---
+  double? detectTaxRate({String? city, String? stateAbbreviation, String? zipCode}) {
+    return TaxService.getTaxRateByAddress(
+      city: city,
+      stateAbbreviation: stateAbbreviation,
+      zipCode: zipCode,
+    );
+  }
+
+  Future<void> saveZipCodeTaxRate(String zipCode, double rate) async {
+    await TaxService.setZipCodeRate(zipCode, rate);
+  }
+
+  Future<void> saveStateTaxRate(String stateAbbreviation, double rate) async {
+    await TaxService.setStateRate(stateAbbreviation, rate);
+  }
+
+  bool get isTaxDatabaseAvailable => TaxService.isDatabaseAvailable;
+  String get taxDatabaseStatus => TaxService.getDatabaseStatus();
   // --- Search Operations ---
   List<Customer> searchCustomers(String query) {
     if (query.isEmpty) return _customers;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -16,6 +16,8 @@ import 'settings_screen.dart';
 import 'customer_detail_screen.dart';
 import 'simplified_quote_detail_screen.dart';
 import 'templates_screen.dart';
+import 'layouts/home_layout_small.dart';
+import 'layouts/home_layout_large.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -71,46 +73,39 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[50],
-      body: PageView(
-        controller: _pageController,
-        onPageChanged: (index) {
-          setState(() {
-            _selectedIndex = index;
-          });
-        },
-        children: [
-          _buildModernDashboard(),
-          const CustomersScreen(),
-          const QuotesScreen(),
-          const ProductsScreen(),
-          const TemplatesScreen(),
-        ],
-      ),
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.1),
-              blurRadius: 10,
-              offset: const Offset(0, -2),
-            ),
-          ],
-        ),
-        child: BottomNavigationBar(
-          type: BottomNavigationBarType.fixed,
-          currentIndex: _selectedIndex,
-          onTap: _onNavItemTapped,
-          items: _navItems,
-          selectedItemColor: RufkoTheme.primaryColor, // Blue from logo
-          unselectedItemColor: Colors.grey[600],
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-        ),
-      ),
-      floatingActionButton: _selectedIndex == 0 ? _buildFloatingActionButton() : null,
+    final pages = [
+      _buildModernDashboard(),
+      const CustomersScreen(),
+      const QuotesScreen(),
+      const ProductsScreen(),
+      const TemplatesScreen(),
+    ];
+
+    final fab = _selectedIndex == 0 ? _buildFloatingActionButton() : null;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isLargeScreen = constraints.maxWidth >= 900;
+        if (isLargeScreen) {
+          return HomeLargeLayout(
+            selectedIndex: _selectedIndex,
+            navItems: _navItems,
+            onItemSelected: _onNavItemTapped,
+            pageController: _pageController,
+            pages: pages,
+            floatingActionButton: fab,
+          );
+        }
+
+        return HomeSmallLayout(
+          selectedIndex: _selectedIndex,
+          navItems: _navItems,
+          onItemSelected: _onNavItemTapped,
+          pageController: _pageController,
+          pages: pages,
+          floatingActionButton: fab,
+        );
+      },
     );
   }
 

--- a/lib/screens/layouts/home_layout_large.dart
+++ b/lib/screens/layouts/home_layout_large.dart
@@ -1,0 +1,55 @@
+// lib/screens/layouts/home_layout_large.dart
+
+import 'package:flutter/material.dart';
+
+class HomeLargeLayout extends StatelessWidget {
+  final int selectedIndex;
+  final List<BottomNavigationBarItem> navItems;
+  final ValueChanged<int> onItemSelected;
+  final PageController pageController;
+  final List<Widget> pages;
+  final Widget? floatingActionButton;
+
+  const HomeLargeLayout({
+    super.key,
+    required this.selectedIndex,
+    required this.navItems,
+    required this.onItemSelected,
+    required this.pageController,
+    required this.pages,
+    this.floatingActionButton,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: selectedIndex,
+            onDestinationSelected: onItemSelected,
+            labelType: NavigationRailLabelType.all,
+            destinations: navItems
+                .map(
+                  (item) => NavigationRailDestination(
+                    icon: item.icon,
+                    label: Text(item.label ?? ''),
+                  ),
+                )
+                .toList(),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            child: PageView(
+              controller: pageController,
+              onPageChanged: onItemSelected,
+              children: pages,
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}

--- a/lib/screens/layouts/home_layout_small.dart
+++ b/lib/screens/layouts/home_layout_small.dart
@@ -1,0 +1,57 @@
+// lib/screens/layouts/home_layout_small.dart
+
+import 'package:flutter/material.dart';
+
+class HomeSmallLayout extends StatelessWidget {
+  final int selectedIndex;
+  final List<BottomNavigationBarItem> navItems;
+  final ValueChanged<int> onItemSelected;
+  final PageController pageController;
+  final List<Widget> pages;
+  final Widget? floatingActionButton;
+
+  const HomeSmallLayout({
+    super.key,
+    required this.selectedIndex,
+    required this.navItems,
+    required this.onItemSelected,
+    required this.pageController,
+    required this.pages,
+    this.floatingActionButton,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      body: PageView(
+        controller: pageController,
+        onPageChanged: onItemSelected,
+        children: pages,
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 10,
+              offset: const Offset(0, -2),
+            ),
+          ],
+        ),
+        child: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          currentIndex: selectedIndex,
+          onTap: onItemSelected,
+          items: navItems,
+          selectedItemColor: Theme.of(context).colorScheme.primary,
+          unselectedItemColor: Colors.grey[600],
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+        ),
+      ),
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,9 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'dart:io';
 import 'package:open_filex/open_filex.dart';
-import '../services/file_service.dart';
 import '../providers/app_state_provider.dart';
-import '../services/database_service.dart';
 import '../models/app_settings.dart';
 
 import 'settings/category_manager_dialog.dart';
@@ -885,11 +883,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       setState(() => _isProcessing = true);
 
-      final databaseService = DatabaseService.instance;
-      final allData = await databaseService.exportAllData();
-
-      final filePath =
-          await FileService.instance.saveExportedData(allData);
+      final appState = context.read<AppStateProvider>();
+      final filePath = await appState.exportAllDataToFile();
 
       if (mounted) {
         final fileName = filePath.split('/').last;
@@ -926,7 +921,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _importData() async {
     try {
-      final data = await FileService.instance.pickAndReadBackupFile();
+      final appState = context.read<AppStateProvider>();
+      final data = await appState.pickBackupData();
       if (!mounted) return;
 
       if (data.isNotEmpty) {
@@ -967,12 +963,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         if (confirmed == true) {
           setState(() => _isProcessing = true);
 
-          final databaseService = DatabaseService.instance;
-          await databaseService.importAllData(data);
-          if (!mounted) return;
-
-          final appState = context.read<AppStateProvider>();
-          await appState.loadAllData();
+          await appState.importAllDataFromFile(data);
           if (!mounted) return;
 
           ScaffoldMessenger.of(context).showSnackBar(
@@ -1081,11 +1072,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 setState(() => _isProcessing = true);
 
                 final appState = context.read<AppStateProvider>();
-                final databaseService = DatabaseService.instance;
 
                 // Clear all data
-                await databaseService.importAllData({});
-                await appState.loadAllData();
+                await appState.clearAllData();
 
                 if (mounted) {
                   messenger.showSnackBar(
@@ -1219,9 +1208,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                 label: const Text('Change'),
                               ),
                               OutlinedButton.icon(
-                                onPressed: () {
-                                  settings.updateCompanyLogo(null);
-                                  appState.updateAppSettings(settings);
+                                onPressed: () async {
+                                  await appState.removeCompanyLogo(settings);
                                   setDialogState(() {});
                                 },
                                 icon: const Icon(Icons.delete),
@@ -1354,14 +1342,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _selectCompanyLogo(StateSetter setDialogState, AppSettings settings, AppStateProvider appState) async {
     final messenger = ScaffoldMessenger.of(context);
     try {
-      final newPath = await FileService.instance.pickAndSaveCompanyLogo();
-
+      final newPath = await appState.pickAndSaveCompanyLogo(settings);
       if (newPath != null) {
-        settings.updateCompanyLogo(newPath);
-        appState.updateAppSettings(settings);
-
         setDialogState(() {});
-
         messenger.showSnackBar(
           SnackBar(
             content: const Text('Company logo updated!'),

--- a/lib/screens/simplified_quote_detail_screen.dart
+++ b/lib/screens/simplified_quote_detail_screen.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
+import 'package:open_filex/open_filex.dart';
 import '../models/simplified_quote.dart';
 import '../models/customer.dart';
 import '../providers/app_state_provider.dart';
@@ -1053,9 +1054,7 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
           content: Text('Preview generated: ${previewPath.split('/').last}'),
           action: SnackBarAction(
             label: 'Open',
-            onPressed: () {
-              // TODO: Open PDF
-            },
+            onPressed: () => OpenFilex.open(previewPath),
           ),
         ),
       );

--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -10,7 +10,6 @@ import '../models/simplified_quote.dart';
 import '../models/quote.dart';
 import '../providers/app_state_provider.dart';
 import 'simplified_quote_detail_screen.dart';
-import '../services/tax_service.dart';
 import '../models/quote_extras.dart'; // NEW: For PermitItem and CustomLineItem
 import 'package:rufko/screens/inspection_viewer_screen.dart';
 import '../theme/rufko_theme.dart';
@@ -2063,7 +2062,7 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
     debugPrint('   City: ${customer.city}');
 
     // Try to get tax rate from local database
-    final detectedRate = TaxService.getTaxRateByAddress(
+    final detectedRate = appState.detectTaxRate(
       city: customer.city,
       stateAbbreviation: customer.stateAbbreviation,
       zipCode: customer.zipCode,
@@ -2223,9 +2222,9 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
 
               // Save to database
               if (customer.zipCode?.isNotEmpty == true) {
-                await TaxService.setZipCodeRate(customer.zipCode!, rate);
+                await appState.saveZipCodeTaxRate(customer.zipCode!, rate);
               } else if (customer.stateAbbreviation?.isNotEmpty == true) {
-                await TaxService.setStateRate(customer.stateAbbreviation!, rate);
+                await appState.saveStateTaxRate(customer.stateAbbreviation!, rate);
               }
 
               // Set for current quote

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -8,7 +8,6 @@ import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
 
 
 import '../models/pdf_template.dart';
-import '../services/template_service.dart';
 import '../providers/app_state_provider.dart';
 import 'pdf_preview_screen.dart';
 import '../theme/rufko_theme.dart';
@@ -745,12 +744,12 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
           return;
         }
 
-        final template = await TemplateService.instance.createTemplateFromPDF(filePath, templateName.trim());
+        final template =
+            await appState.createPDFTemplateFromFile(filePath, templateName.trim());
         _setLoading(false);
 
         if (!mounted) return;
         if (template != null) {
-          await appState.addExistingPDFTemplateToList(template);
 
           setState(() {
             _currentTemplate = template;
@@ -830,10 +829,12 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   void _previewTemplate() async {
     if (_currentTemplate == null) return;
     _setLoading(true, 'Generating preview...');
+    final appState = context.read<AppStateProvider>();
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
     try {
-      final previewPath = await TemplateService.instance.generateTemplatePreview(_currentTemplate!);
+      final previewPath =
+          await appState.generateTemplatePreview(_currentTemplate!);
       _setLoading(false);
 
       if (!mounted) return;

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import '../models/message_template.dart';
 import '../models/pdf_template.dart';
 import '../providers/app_state_provider.dart';
-import '../services/template_service.dart';
 import 'template_editor_screen.dart';
 import 'pdf_preview_screen.dart';
 import 'custom_app_data_screen.dart';
@@ -1984,8 +1983,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
         ),
       );
 
+      final appState = context.read<AppStateProvider>();
       final previewPath =
-          await TemplateService.instance.generateTemplatePreview(template);
+          await appState.generateTemplatePreview(template);
 
       navigator.pop(); // Close loading dialog
 

--- a/lib/theme/rufko_theme.dart
+++ b/lib/theme/rufko_theme.dart
@@ -38,6 +38,16 @@ mixin RufkoTheme {
           borderRadius: BorderRadius.circular(12),
         ),
       ),
+      navigationRailTheme: NavigationRailThemeData(
+        backgroundColor: Colors.white,
+        selectedIconTheme: const IconThemeData(color: primaryColor),
+        selectedLabelTextStyle: const TextStyle(
+          color: primaryColor,
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedIconTheme: IconThemeData(color: Colors.grey.shade600),
+        unselectedLabelTextStyle: TextStyle(color: Colors.grey.shade600),
+      ),
       inputDecorationTheme: InputDecorationTheme(
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
## Summary
- centralize tax helper calls in `AppStateProvider`
- remove direct `TaxService` usage in `SimplifiedQuoteScreen`
- handle PDF preview action in `SimplifiedQuoteDetailScreen`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e051a5e0832ca3d74c2865201c59