### PR TITLE
Fix missing paren in stats card

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -417,6 +417,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                           ),
                         ),
                       ),
+                    ),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- fix closing of `Flexible` widget in `home_screen.dart`

## Testing
- `dart format lib/screens/home_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f0a528f4832c82445eaf7f117d9d