### PR TITLE
Rename App Data terminology to Fields

### DIFF
--- a/lib/models/email_template.dart
+++ b/lib/models/email_template.dart
@@ -320,10 +320,10 @@ class EmailTemplate extends HiveObject {
 
       if (field is Map<String, dynamic>) {
         fieldName = field['fieldName'] as String? ?? '';
-        category = field['category'] as String? ?? 'Custom Fields';
+        category = field['category'] as String? ?? 'Fields';
       } else {
         fieldName = field.fieldName as String? ?? '';
-        category = field.category as String? ?? 'Custom Fields';
+        category = field.category as String? ?? 'Fields';
       }
 
       if (fieldName.isNotEmpty) {

--- a/lib/models/message_template.dart
+++ b/lib/models/message_template.dart
@@ -334,10 +334,10 @@ class MessageTemplate extends HiveObject {
 
       if (field is Map<String, dynamic>) {
         fieldName = field['fieldName'] as String? ?? '';
-        category = field['category'] as String? ?? 'Custom Fields';
+        category = field['category'] as String? ?? 'Fields';
       } else {
         fieldName = field.fieldName as String? ?? '';
-        category = field.category as String? ?? 'Custom Fields';
+        category = field.category as String? ?? 'Fields';
       }
 
       if (fieldName.isNotEmpty) {

--- a/lib/models/pdf_template.dart
+++ b/lib/models/pdf_template.dart
@@ -229,7 +229,7 @@ class PDFTemplate extends HiveObject {
         'notes', 'terms', 'upgradeQuoteText'
       ],
 
-      'Custom Fields': [
+      'Fields': [
         'customText1', 'customText2', 'customText3',
         'customNumeric1', 'customNumeric2',
         'customDate1', 'customDate2',
@@ -312,7 +312,7 @@ class PDFTemplate extends HiveObject {
         'contact': 'Contact Information', // Will create new if doesn't exist
         'legal': 'Legal Information',
         'pricing': 'Pricing Information',
-        'custom': 'Custom App Data',
+        'custom': 'Fields',
       };
 
       // Process each custom field category

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -234,7 +234,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
       // Start with empty list
       List<Map<String, dynamic>> relevantCategories = [];
 
-      // For Custom Fields, ALWAYS add protected "inspection" category first
+      // For Fields, ALWAYS add protected "inspection" category first
       if (templateType == 'Fields') {
         relevantCategories.add({
           'id': 'protected_inspection',

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -3071,7 +3071,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Go to Templates → Custom App Data Fields\nand create fields with "Inspection" category',
+                  'Go to Templates → Fields\nand create fields with "Inspection" category',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Colors.grey[500],
                   ),
@@ -3080,10 +3080,10 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 const SizedBox(height: 24),
                 ElevatedButton.icon(
                   onPressed: () {
-                    // Navigate to custom fields screen (placeholder for now)
+                    // Navigate to fields screen (placeholder for now)
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
-                        content: Text('Navigation to Custom Fields coming soon'),
+                        content: Text('Navigation to Fields coming soon'),
                         backgroundColor: Colors.blue,
                       ),
                     );

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -479,6 +479,13 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
                 icon: const Icon(Icons.close),
                 onPressed: () => Navigator.pop(context),
               ),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.help_outline),
+                  tooltip: 'Mapping help',
+                  onPressed: _showMappingHelp,
+                ),
+              ],
             ),
             body: _buildAppDataFieldsList(pdfFieldInfo),
           ),
@@ -727,6 +734,25 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       const SnackBar(
         content: Text("Field mapping removed."),
         backgroundColor: Colors.orange,
+      ),
+    );
+  }
+
+  void _showMappingHelp() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('How to Map Fields'),
+        content: const Text(
+          'Select a field from the list to link it with the chosen PDF field. '\
+          'Existing links can be replaced by choosing another field.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/app_state_provider.dart';
 import 'template_editor_screen.dart';
-import '../widgets/templates/custom_app_data_tab.dart';
+import '../widgets/templates/fields_tab.dart';
 import '../widgets/templates/pdf_templates_tab.dart';
 import '../widgets/templates/message_templates_tab.dart';
 import '../widgets/templates/email_templates_tab.dart';
@@ -13,7 +13,7 @@ import '../widgets/templates/dialgos/message_template_editor.dart';
 import '../widgets/templates/dialgos/email_template_editor.dart';
 import 'category_management_screen.dart';
 import '../models/custom_app_data.dart';
-import '../widgets/templates/dialgos/add_custom_field_dialog.dart';
+import '../widgets/templates/dialgos/add_field_dialog.dart';
 
 class TemplatesScreen extends StatefulWidget {
   const TemplatesScreen({super.key});
@@ -61,7 +61,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                     PdfTemplatesTab(),
                     MessageTemplatesTab(),
                     EmailTemplatesTab(),
-                    CustomAppDataScreen(),
+                    FieldsTab(),
                   ],
                 ),
               ),
@@ -154,12 +154,12 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               label: const Text('New Email Template'),
               backgroundColor: Colors.orange,
             );
-          case 3: // Custom Fields tab
+          case 3: // Fields tab
             return FloatingActionButton.extended(
               heroTag: "custom_fields_fab",
               onPressed: _createNewCustomField,
               icon: const Icon(Icons.add),
-              label: const Text('New Custom Field'),
+              label: const Text('New Field'),
               backgroundColor: RufkoTheme.primaryColor,
             );
           default:
@@ -236,7 +236,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Header - matching add_custom_field_dialog style
+                    // Header - matching add_field_dialog style
                     Container(
                       padding: const EdgeInsets.fromLTRB(20, 16, 16, 8),
                       decoration: const BoxDecoration(
@@ -367,7 +367,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                       ),
                     ),
 
-                    // Actions - matching add_custom_field_dialog style
+                    // Actions - matching add_field_dialog style
                     Container(
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
@@ -562,9 +562,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _createNewCustomField() async {
-    // Use the static method from AddCustomFieldDialog which handles everything properly
+    // Use the static method from AddFieldDialog which handles everything properly
     try {
-      final result = await AddCustomFieldDialog.show(context);
+      final result = await AddFieldDialog.show(context);
 
       if (result != null && mounted) {
         final appState = context.read<AppStateProvider>();

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -701,8 +701,8 @@ class DatabaseService {
       await _mediaBox.clear();
       await _settingsBox.clear();
       await _pdfTemplateBox.clear();
-      await _customAppDataFieldBox.clear(); // ADDED: Clear custom fields
-      await _inspectionDocumentBox.clear(); // ADDED: Clear custom fields
+      await _customAppDataFieldBox.clear(); // ADDED: Clear fields
+      await _inspectionDocumentBox.clear(); // ADDED: Clear fields
       await _categoriesBox.clear(); // Clear template categories
       await _messageTemplateBox.clear();
       await _emailTemplateBox.clear();
@@ -1091,7 +1091,7 @@ class DatabaseService {
         return _emailTemplateBox.values
             .where((t) => t.category == categoryKey)
             .length;
-      case 'Custom Fields': // This refers to the category of CustomAppDataField itself
+      case 'Fields': // This refers to the category of CustomAppDataField itself
         return _customAppDataFieldBox.values
             .where((f) => f.category == categoryKey)
             .length;

--- a/lib/utils/template_validator.dart
+++ b/lib/utils/template_validator.dart
@@ -112,10 +112,10 @@ class TemplateValidator {
   /// Validate individual FieldMapping properties
   static void _validateFieldMapping(FieldMapping field, PDFTemplate template, TemplateValidationResult result) {
     if (field.appDataType.isEmpty || field.appDataType.startsWith('unmapped_')) {
-      result.addWarning('Field linked to PDF field "${field.pdfFormFieldName}" has no App Data Source assigned.');
+      result.addWarning('Field linked to PDF field "${field.pdfFormFieldName}" has no Field Source assigned.');
     }
     if (field.pdfFormFieldName.isEmpty) {
-      result.addError('App Data Source "${PDFTemplate.getFieldDisplayName(field.appDataType)}" is not linked to any PDF Form Field.');
+      result.addError('Field Source "${PDFTemplate.getFieldDisplayName(field.appDataType)}" is not linked to any PDF Form Field.');
     }
 
     // Validate visual hints if they are populated (they are optional now)

--- a/lib/widgets/templates/dialgos/add_field_dialog.dart
+++ b/lib/widgets/templates/dialgos/add_field_dialog.dart
@@ -1,4 +1,4 @@
-// lib/widgets/add_custom_field_dialog.dart
+// lib/widgets/add_field_dialog.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,12 +7,12 @@ import '../../../providers/app_state_provider.dart';
 import '../../../mixins/field_type_mixin.dart';
 import '../../../theme/rufko_theme.dart';
 
-class AddCustomFieldDialog extends StatefulWidget {
+class AddFieldDialog extends StatefulWidget {
   final List<String> categories;
   final Map<String, String> categoryNames;
   final String? preSelectedCategory;
 
-  const AddCustomFieldDialog({
+  const AddFieldDialog({
     super.key,
     required this.categories,
     required this.categoryNames,
@@ -23,7 +23,7 @@ class AddCustomFieldDialog extends StatefulWidget {
   static Future<CustomAppDataField?> show(BuildContext context, {String? preSelectedCategory}) async {
     final appState = context.read<AppStateProvider>();
 
-    // Get available categories for custom fields
+    // Get available categories for fields
     final allTemplateCategories = appState.templateCategories;
     final customFieldCategories = allTemplateCategories
         .where((cat) => cat.templateType == 'custom_fields')
@@ -61,7 +61,7 @@ class AddCustomFieldDialog extends StatefulWidget {
       context: context,
       barrierDismissible: false,
       builder: (BuildContext dialogContext) {
-        return AddCustomFieldDialog(
+        return AddFieldDialog(
           categories: availableCategories,
           categoryNames: categoryNames,
           preSelectedCategory: preSelectedCategory,
@@ -123,7 +123,7 @@ class AddCustomFieldDialog extends StatefulWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const Text(
-                        'Create a new category for custom fields:',
+                        'Create a new category for fields:',
                         style: TextStyle(fontSize: 14, color: Colors.grey),
                       ),
                       const SizedBox(height: 16),
@@ -208,10 +208,10 @@ class AddCustomFieldDialog extends StatefulWidget {
   }
 
   @override
-  State<AddCustomFieldDialog> createState() => _AddCustomFieldDialogState();
+  State<AddFieldDialog> createState() => _AddFieldDialogState();
 }
 
-class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
+class _AddFieldDialogState extends State<AddFieldDialog>
     with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
   final _fieldNameController = TextEditingController();
@@ -250,7 +250,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
     }
     _valueTextController.text = 'false';
 
-    debugPrint('🎯 AddCustomFieldDialog initialized with category: $_selectedFieldCategory');
+    debugPrint('🎯 AddFieldDialog initialized with category: $_selectedFieldCategory');
   }
 
   @override
@@ -358,7 +358,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                         onChanged: (String? newValue) async {
                           if (newValue == _createNewCategoryValue) {
                             // Show create category dialog
-                            final newCategory = await AddCustomFieldDialog._createNewCategoryAndReturn(context);
+                            final newCategory = await AddFieldDialog._createNewCategoryAndReturn(context);
                             if (newCategory != null && mounted) {
                               // Update the local categories and select the new one
                               final appState = context.read<AppStateProvider>();
@@ -473,71 +473,74 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                       ),
                       const SizedBox(height: 12),
 
-                      // Current Value - Different UI for checkbox vs other types
-                      if (_selectedFieldType == 'checkbox') ...[
-                        Container(
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey.shade400),
-                            borderRadius: BorderRadius.circular(4),
+                      ExpansionTile(
+                        tilePadding: EdgeInsets.zero,
+                        title: const Text('Advanced Options', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                        children: [
+                          const SizedBox(height: 8),
+                          if (_selectedFieldType == 'checkbox')
+                            Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(color: Colors.grey.shade400),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: CheckboxListTile(
+                                title: const Text('Default State', style: TextStyle(fontSize: 14)),
+                                subtitle: const Text('Initial checkbox value', style: TextStyle(fontSize: 12)),
+                                value: _checkboxValue,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    _checkboxValue = value ?? false;
+                                    _valueTextController.text = _checkboxValue.toString();
+                                  });
+                                },
+                                controlAffinity: ListTileControlAffinity.leading,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                              ),
+                            )
+                          else
+                            TextFormField(
+                              controller: _valueTextController,
+                              decoration: const InputDecoration(
+                                labelText: 'Default Value',
+                                hintText: 'Enter default value',
+                                isDense: true,
+                                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                border: OutlineInputBorder(),
+                              ),
+                              style: const TextStyle(fontSize: 14),
+                              maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
+                              keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
+                              _selectedFieldType == 'email' ? TextInputType.emailAddress :
+                              _selectedFieldType == 'phone' ? TextInputType.phone :
+                              TextInputType.text,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Enter default value';
+                                }
+                                return null;
+                              },
+                            ),
+                          const SizedBox(height: 12),
+                          Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(color: Colors.grey.shade300),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: CheckboxListTile(
+                              title: const Text('Required Field', style: TextStyle(fontSize: 14)),
+                              subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
+                              value: _isRequired,
+                              onChanged: (bool? value) {
+                                setState(() {
+                                  _isRequired = value ?? false;
+                                });
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                            ),
                           ),
-                          child: CheckboxListTile(
-                            title: const Text('Default State', style: TextStyle(fontSize: 14)),
-                            subtitle: const Text('Initial checkbox value', style: TextStyle(fontSize: 12)),
-                            value: _checkboxValue,
-                            onChanged: (bool? value) {
-                              setState(() {
-                                _checkboxValue = value ?? false;
-                                _valueTextController.text = _checkboxValue.toString();
-                              });
-                            },
-                            controlAffinity: ListTileControlAffinity.leading,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                        ),
-                      ] else ...[
-                        TextFormField(
-                          controller: _valueTextController,
-                          decoration: const InputDecoration(
-                            labelText: 'Default Value',
-                            hintText: 'Enter default value',
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                            border: OutlineInputBorder(),
-                          ),
-                          style: const TextStyle(fontSize: 14),
-                          maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
-                          keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
-                          _selectedFieldType == 'email' ? TextInputType.emailAddress :
-                          _selectedFieldType == 'phone' ? TextInputType.phone :
-                          TextInputType.text,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Enter default value';
-                            }
-                            return null;
-                          },
-                        ),
-                      ],
-                      const SizedBox(height: 12),
-
-                      // Required checkbox - compact
-                      Container(
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey.shade300),
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: CheckboxListTile(
-                          title: const Text('Required Field', style: TextStyle(fontSize: 14)),
-                          subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
-                          value: _isRequired,
-                          onChanged: (bool? value) {
-                            setState(() {
-                              _isRequired = value ?? false;
-                            });
-                          },
-                          controlAffinity: ListTileControlAffinity.leading,
-                          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                        ),
+                        ],
                       ),
                     ],
                   ),

--- a/lib/widgets/templates/dialgos/edit_field_dialog.dart
+++ b/lib/widgets/templates/dialgos/edit_field_dialog.dart
@@ -1,4 +1,4 @@
-// lib/widgets/edit_custom_field_dialog.dart
+// lib/widgets/edit_field_dialog.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,12 +7,12 @@ import '../../../providers/app_state_provider.dart';
 import '../../../mixins/field_type_mixin.dart';
 import '../../../theme/rufko_theme.dart';
 
-class EditCustomFieldDialog extends StatefulWidget {
+class EditFieldDialog extends StatefulWidget {
   final CustomAppDataField field;
   final List<String> categories;
   final Map<String, String> categoryNames;
 
-  const EditCustomFieldDialog({
+  const EditFieldDialog({
     super.key,
     required this.field,
     required this.categories,
@@ -73,7 +73,7 @@ class EditCustomFieldDialog extends StatefulWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const Text(
-                        'Create a new category for custom fields:',
+                        'Create a new category for fields:',
                         style: TextStyle(fontSize: 14, color: Colors.grey),
                       ),
                       const SizedBox(height: 16),
@@ -158,10 +158,10 @@ class EditCustomFieldDialog extends StatefulWidget {
   }
 
   @override
-  State<EditCustomFieldDialog> createState() => _EditCustomFieldDialogState();
+  State<EditFieldDialog> createState() => _EditFieldDialogState();
 }
 
-class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
+class _EditFieldDialogState extends State<EditFieldDialog>
     with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _fieldNameController;
@@ -318,7 +318,7 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                         onChanged: (String? newValue) async {
                           if (newValue == _createNewCategoryValue) {
                             // Show create category dialog
-                            final newCategory = await EditCustomFieldDialog._createNewCategoryAndReturn(context);
+                            final newCategory = await EditFieldDialog._createNewCategoryAndReturn(context);
                             if (newCategory != null && mounted) {
                               // Update the local categories and select the new one
                               final appState = context.read<AppStateProvider>();
@@ -434,71 +434,75 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                       ),
                       const SizedBox(height: 12),
 
-                      // Current Value - Different UI for checkbox vs other types
-                      if (_selectedFieldType == 'checkbox') ...[
-                        Container(
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey.shade400),
-                            borderRadius: BorderRadius.circular(4),
+                      ExpansionTile(
+                        tilePadding: EdgeInsets.zero,
+                        title: const Text('Advanced Options', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                        children: [
+                          const SizedBox(height: 8),
+                          if (_selectedFieldType == 'checkbox')
+                            Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(color: Colors.grey.shade400),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: CheckboxListTile(
+                                title: const Text('Current State', style: TextStyle(fontSize: 14)),
+                                subtitle: const Text('Current checkbox value', style: TextStyle(fontSize: 12)),
+                                value: _checkboxValue,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    _checkboxValue = value ?? false;
+                                    _valueTextController.text = _checkboxValue.toString();
+                                  });
+                                },
+                                controlAffinity: ListTileControlAffinity.leading,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                              ),
+                            )
+                          else
+                            TextFormField(
+                              controller: _valueTextController,
+                              decoration: const InputDecoration(
+                                labelText: 'Current Value',
+                                hintText: 'Enter current value',
+                                isDense: true,
+                                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                border: OutlineInputBorder(),
+                              ),
+                              style: const TextStyle(fontSize: 14),
+                              maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
+                              keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
+                              _selectedFieldType == 'email' ? TextInputType.emailAddress :
+                              _selectedFieldType == 'phone' ? TextInputType.phone :
+                              TextInputType.text,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Enter current value';
+                                }
+                                return null;
+                              },
+                            ),
+                          const SizedBox(height: 12),
+                          Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(color: Colors.grey.shade300),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: CheckboxListTile(
+                              title: const Text('Required Field', style: TextStyle(fontSize: 14)),
+                              subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
+                              value: _isRequired,
+                              onChanged: (bool? value) {
+                                setState(() {
+                                  _isRequired = value ?? false;
+                                });
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                            ),
                           ),
-                          child: CheckboxListTile(
-                            title: const Text('Current State', style: TextStyle(fontSize: 14)),
-                            subtitle: const Text('Current checkbox value', style: TextStyle(fontSize: 12)),
-                            value: _checkboxValue,
-                            onChanged: (bool? value) {
-                              setState(() {
-                                _checkboxValue = value ?? false;
-                                _valueTextController.text = _checkboxValue.toString();
-                              });
-                            },
-                            controlAffinity: ListTileControlAffinity.leading,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                        ),
-                      ] else ...[
-                        TextFormField(
-                          controller: _valueTextController,
-                          decoration: const InputDecoration(
-                            labelText: 'Current Value',
-                            hintText: 'Enter current value',
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                            border: OutlineInputBorder(),
-                          ),
-                          style: const TextStyle(fontSize: 14),
-                          maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
-                          keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
-                          _selectedFieldType == 'email' ? TextInputType.emailAddress :
-                          _selectedFieldType == 'phone' ? TextInputType.phone :
-                          TextInputType.text,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Enter current value';
-                            }
-                            return null;
-                          },
-                        ),
-                      ],
-                      const SizedBox(height: 12),
-
-                      // Required checkbox - compact
-                      Container(
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey.shade300),
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: CheckboxListTile(
-                          title: const Text('Required Field', style: TextStyle(fontSize: 14)),
-                          subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
-                          value: _isRequired,
-                          onChanged: (bool? value) {
-                            setState(() {
-                              _isRequired = value ?? false;
-                            });
-                          },
-                          controlAffinity: ListTileControlAffinity.leading,
-                          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                        ),
+                        ],
+                      ),
                       ),
                     ],
                   ),

--- a/lib/widgets/templates/fields_tab.dart
+++ b/lib/widgets/templates/fields_tab.dart
@@ -2,20 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/custom_app_data.dart';
 import '../../providers/app_state_provider.dart';
-import 'dialgos/add_custom_field_dialog.dart';
-import 'dialgos/edit_custom_field_dialog.dart';
+import 'dialgos/add_field_dialog.dart';
+import 'dialgos/edit_field_dialog.dart';
 import '../../utils/common_utils.dart';
 import '../../theme/rufko_theme.dart';
 import '../../mixins/template_tab_mixin.dart';
 
-class CustomAppDataScreen extends StatefulWidget {
-  const CustomAppDataScreen({super.key});
+class FieldsTab extends StatefulWidget {
+  const FieldsTab({super.key});
 
   @override
-  State<CustomAppDataScreen> createState() => _CustomAppDataScreenState();
+  State<FieldsTab> createState() => _FieldsTabState();
 }
 
-class _CustomAppDataScreenState extends State<CustomAppDataScreen> with TemplateTabMixin {
+class _FieldsTabState extends State<FieldsTab> with TemplateTabMixin {
 
   // Implement required mixin properties
   @override
@@ -267,7 +267,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
     return Scaffold(
       backgroundColor: Colors.grey[50],
       appBar: AppBar(
-        title: const Text('Custom App Data'),
+        title: const Text('Fields'),
         backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         elevation: 0,
@@ -292,7 +292,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
     );
   }
 
-  // Field-specific helper methods (these are unique to custom fields)
+  // Field-specific helper methods (these are unique to fields)
   Color _getFieldTypeColor(String fieldType) {
     switch (fieldType) {
       case 'text': return Colors.blue;
@@ -358,7 +358,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
               categoryNames[categoryKey] = categoryName;
             }
 
-            return AddCustomFieldDialog(
+            return AddFieldDialog(
               categories: availableCategories,
               categoryNames: categoryNames,
             );
@@ -414,7 +414,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
               }
             }
 
-            return EditCustomFieldDialog(
+            return EditFieldDialog(
               field: field,
               categories: availableCategories,
               categoryNames: categoryNames,
@@ -457,7 +457,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title: const Text('Delete Custom Field'),
+          title: const Text('Delete Field'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- rename custom fields files to use simpler "field" naming
- collapse advanced options for default value and required state
- add help button in field mapping screen for guidance
- wire new dialog and tab names across the app

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846316b9138832ca99d5f670c51b758