### PR TITLE
Rename App Data terminology to Fields

### DIFF
--- a/lib/models/email_template.dart
+++ b/lib/models/email_template.dart
@@ -320,10 +320,10 @@ class EmailTemplate extends HiveObject {
 
       if (field is Map<String, dynamic>) {
         fieldName = field['fieldName'] as String? ?? '';
-        category = field['category'] as String? ?? 'Custom Fields';
+        category = field['category'] as String? ?? 'Fields';
       } else {
         fieldName = field.fieldName as String? ?? '';
-        category = field.category as String? ?? 'Custom Fields';
+        category = field.category as String? ?? 'Fields';
       }
 
       if (fieldName.isNotEmpty) {

--- a/lib/models/message_template.dart
+++ b/lib/models/message_template.dart
@@ -334,10 +334,10 @@ class MessageTemplate extends HiveObject {
 
       if (field is Map<String, dynamic>) {
         fieldName = field['fieldName'] as String? ?? '';
-        category = field['category'] as String? ?? 'Custom Fields';
+        category = field['category'] as String? ?? 'Fields';
       } else {
         fieldName = field.fieldName as String? ?? '';
-        category = field.category as String? ?? 'Custom Fields';
+        category = field.category as String? ?? 'Fields';
       }
 
       if (fieldName.isNotEmpty) {

--- a/lib/models/pdf_template.dart
+++ b/lib/models/pdf_template.dart
@@ -229,7 +229,7 @@ class PDFTemplate extends HiveObject {
         'notes', 'terms', 'upgradeQuoteText'
       ],
 
-      'Custom Fields': [
+      'Fields': [
         'customText1', 'customText2', 'customText3',
         'customNumeric1', 'customNumeric2',
         'customDate1', 'customDate2',
@@ -312,7 +312,7 @@ class PDFTemplate extends HiveObject {
         'contact': 'Contact Information', // Will create new if doesn't exist
         'legal': 'Legal Information',
         'pricing': 'Pricing Information',
-        'custom': 'Custom App Data',
+        'custom': 'Fields',
       };
 
       // Process each custom field category

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -234,7 +234,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen>
       // Start with empty list
       List<Map<String, dynamic>> relevantCategories = [];
 
-      // For Custom Fields, ALWAYS add protected "inspection" category first
+      // For Fields, ALWAYS add protected "inspection" category first
       if (templateType == 'Fields') {
         relevantCategories.add({
           'id': 'protected_inspection',

--- a/lib/screens/customer_detail_screen.dart
+++ b/lib/screens/customer_detail_screen.dart
@@ -3071,7 +3071,7 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Go to Templates → Custom App Data Fields\nand create fields with "Inspection" category',
+                  'Go to Templates → Fields\nand create fields with "Inspection" category',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Colors.grey[500],
                   ),
@@ -3080,10 +3080,10 @@ class _CustomerDetailScreenState extends State<CustomerDetailScreen>
                 const SizedBox(height: 24),
                 ElevatedButton.icon(
                   onPressed: () {
-                    // Navigate to custom fields screen (placeholder for now)
+                    // Navigate to fields screen (placeholder for now)
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
-                        content: Text('Navigation to Custom Fields coming soon'),
+                        content: Text('Navigation to Fields coming soon'),
                         backgroundColor: Colors.blue,
                       ),
                     );

--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -479,6 +479,13 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
                 icon: const Icon(Icons.close),
                 onPressed: () => Navigator.pop(context),
               ),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.help_outline),
+                  tooltip: 'Mapping help',
+                  onPressed: _showMappingHelp,
+                ),
+              ],
             ),
             body: _buildAppDataFieldsList(pdfFieldInfo),
           ),
@@ -680,7 +687,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       pdfFormFieldName: pdfFieldName,
       detectedPdfFieldType: PdfFormFieldType.values.firstWhere(
             (e) => e.toString() == pdfFieldInfo['type'],
-        orElse: () => PdfFormFieldType. unknown,
+        orElse: () => PdfFormFieldType.unknown,
       ),
       pageNumber: pdfFieldInfo['page'] as int,
     );
@@ -715,7 +722,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
 
     setState(() {
       mapping.pdfFormFieldName = '';
-      mapping.detectedPdfFieldType = PdfFormFieldType. unknown;
+      mapping.detectedPdfFieldType = PdfFormFieldType.unknown;
       mapping.visualX = null;
       mapping.visualY = null;
       mapping.visualWidth = null;
@@ -727,6 +734,25 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       const SnackBar(
         content: Text("Field mapping removed."),
         backgroundColor: Colors.orange,
+      ),
+    );
+  }
+
+  void _showMappingHelp() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('How to Map Fields'),
+        content: const Text(
+          'Select a field from the list to link it with the chosen PDF field. '
+          'Existing links can be replaced by choosing another field.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/templates_screen.dart
+++ b/lib/screens/templates_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/app_state_provider.dart';
 import 'template_editor_screen.dart';
-import '../widgets/templates/custom_app_data_tab.dart';
+import '../widgets/templates/fields_tab.dart';
 import '../widgets/templates/pdf_templates_tab.dart';
 import '../widgets/templates/message_templates_tab.dart';
 import '../widgets/templates/email_templates_tab.dart';
@@ -12,8 +12,7 @@ import '../theme/rufko_theme.dart';
 import '../widgets/templates/dialgos/message_template_editor.dart';
 import '../widgets/templates/dialgos/email_template_editor.dart';
 import 'category_management_screen.dart';
-import '../models/custom_app_data.dart';
-import '../widgets/templates/dialgos/add_custom_field_dialog.dart';
+import '../widgets/templates/dialgos/add_field_dialog.dart';
 
 class TemplatesScreen extends StatefulWidget {
   const TemplatesScreen({super.key});
@@ -61,7 +60,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                     PdfTemplatesTab(),
                     MessageTemplatesTab(),
                     EmailTemplatesTab(),
-                    CustomAppDataScreen(),
+                    FieldsTab(),
                   ],
                 ),
               ),
@@ -154,12 +153,12 @@ class _TemplatesScreenState extends State<TemplatesScreen>
               label: const Text('New Email Template'),
               backgroundColor: Colors.orange,
             );
-          case 3: // Custom Fields tab
+          case 3: // Fields tab
             return FloatingActionButton.extended(
               heroTag: "custom_fields_fab",
               onPressed: _createNewCustomField,
               icon: const Icon(Icons.add),
-              label: const Text('New Custom Field'),
+              label: const Text('New Field'),
               backgroundColor: RufkoTheme.primaryColor,
             );
           default:
@@ -236,7 +235,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Header - matching add_custom_field_dialog style
+                    // Header - matching add_field_dialog style
                     Container(
                       padding: const EdgeInsets.fromLTRB(20, 16, 16, 8),
                       decoration: const BoxDecoration(
@@ -367,7 +366,7 @@ class _TemplatesScreenState extends State<TemplatesScreen>
                       ),
                     ),
 
-                    // Actions - matching add_custom_field_dialog style
+                    // Actions - matching add_field_dialog style
                     Container(
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
@@ -562,9 +561,9 @@ class _TemplatesScreenState extends State<TemplatesScreen>
   }
 
   void _createNewCustomField() async {
-    // Use the static method from AddCustomFieldDialog which handles everything properly
+    // Use the static method from AddFieldDialog which handles everything properly
     try {
-      final result = await AddCustomFieldDialog.show(context);
+      final result = await AddFieldDialog.show(context);
 
       if (result != null && mounted) {
         final appState = context.read<AppStateProvider>();

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -701,8 +701,8 @@ class DatabaseService {
       await _mediaBox.clear();
       await _settingsBox.clear();
       await _pdfTemplateBox.clear();
-      await _customAppDataFieldBox.clear(); // ADDED: Clear custom fields
-      await _inspectionDocumentBox.clear(); // ADDED: Clear custom fields
+      await _customAppDataFieldBox.clear(); // ADDED: Clear fields
+      await _inspectionDocumentBox.clear(); // ADDED: Clear fields
       await _categoriesBox.clear(); // Clear template categories
       await _messageTemplateBox.clear();
       await _emailTemplateBox.clear();
@@ -1091,7 +1091,7 @@ class DatabaseService {
         return _emailTemplateBox.values
             .where((t) => t.category == categoryKey)
             .length;
-      case 'Custom Fields': // This refers to the category of CustomAppDataField itself
+      case 'Fields': // This refers to the category of CustomAppDataField itself
         return _customAppDataFieldBox.values
             .where((f) => f.category == categoryKey)
             .length;

--- a/lib/utils/template_validator.dart
+++ b/lib/utils/template_validator.dart
@@ -112,10 +112,10 @@ class TemplateValidator {
   /// Validate individual FieldMapping properties
   static void _validateFieldMapping(FieldMapping field, PDFTemplate template, TemplateValidationResult result) {
     if (field.appDataType.isEmpty || field.appDataType.startsWith('unmapped_')) {
-      result.addWarning('Field linked to PDF field "${field.pdfFormFieldName}" has no App Data Source assigned.');
+      result.addWarning('Field linked to PDF field "${field.pdfFormFieldName}" has no Field Source assigned.');
     }
     if (field.pdfFormFieldName.isEmpty) {
-      result.addError('App Data Source "${PDFTemplate.getFieldDisplayName(field.appDataType)}" is not linked to any PDF Form Field.');
+      result.addError('Field Source "${PDFTemplate.getFieldDisplayName(field.appDataType)}" is not linked to any PDF Form Field.');
     }
 
     // Validate visual hints if they are populated (they are optional now)

--- a/lib/widgets/templates/dialgos/add_field_dialog.dart
+++ b/lib/widgets/templates/dialgos/add_field_dialog.dart
@@ -1,4 +1,4 @@
-// lib/widgets/edit_custom_field_dialog.dart
+// lib/widgets/add_field_dialog.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,19 +7,69 @@ import '../../../providers/app_state_provider.dart';
 import '../../../mixins/field_type_mixin.dart';
 import '../../../theme/rufko_theme.dart';
 
-class EditCustomFieldDialog extends StatefulWidget {
-  final CustomAppDataField field;
+class AddFieldDialog extends StatefulWidget {
   final List<String> categories;
   final Map<String, String> categoryNames;
+  final String? preSelectedCategory;
 
-  const EditCustomFieldDialog({
+  const AddFieldDialog({
     super.key,
-    required this.field,
     required this.categories,
     required this.categoryNames,
+    this.preSelectedCategory,
   });
 
-  // Static method to create a new category
+  // Static method to show dialog with category check
+  static Future<CustomAppDataField?> show(BuildContext context, {String? preSelectedCategory}) async {
+    final appState = context.read<AppStateProvider>();
+
+    // Get available categories for fields
+    final allTemplateCategories = appState.templateCategories;
+    final customFieldCategories = allTemplateCategories
+        .where((cat) => cat.templateType == 'custom_fields')
+        .toList();
+
+    // If no categories exist, prompt to create one
+    if (customFieldCategories.isEmpty) {
+      final newCategory = await _createNewCategoryAndReturn(context);
+      if (newCategory == null) return null; // User cancelled
+
+      // Reload categories after creation
+      await appState.loadTemplateCategories();
+      final updatedCategories = appState.templateCategories
+          .where((cat) => cat.templateType == 'custom_fields')
+          .toList();
+
+      if (updatedCategories.isEmpty) return null; // Still no categories
+      preSelectedCategory = newCategory; // Select the newly created category
+    }
+
+    // Now show the field dialog
+    final finalCategories = appState.templateCategories
+        .where((cat) => cat.templateType == 'custom_fields')
+        .toList();
+
+    final availableCategories = <String>[];
+    final categoryNames = <String, String>{};
+
+    for (final category in finalCategories) {
+      availableCategories.add(category.key);
+      categoryNames[category.key] = category.name;
+    }
+
+    return showDialog<CustomAppDataField?>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext dialogContext) {
+        return AddFieldDialog(
+          categories: availableCategories,
+          categoryNames: categoryNames,
+          preSelectedCategory: preSelectedCategory,
+        );
+      },
+    );
+  }
+
   static Future<String?> _createNewCategoryAndReturn(BuildContext context) async {
     final TextEditingController controller = TextEditingController();
 
@@ -73,7 +123,7 @@ class EditCustomFieldDialog extends StatefulWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const Text(
-                        'Create a new category for custom fields:',
+                        'Create a new category for fields:',
                         style: TextStyle(fontSize: 14, color: Colors.grey),
                       ),
                       const SizedBox(height: 16),
@@ -158,23 +208,23 @@ class EditCustomFieldDialog extends StatefulWidget {
   }
 
   @override
-  State<EditCustomFieldDialog> createState() => _EditCustomFieldDialogState();
+  State<AddFieldDialog> createState() => _AddFieldDialogState();
 }
 
-class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
+class _AddFieldDialogState extends State<AddFieldDialog>
     with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _fieldNameController;
-  late final TextEditingController _displayNameController;
-  late final TextEditingController _valueTextController;
+  final _fieldNameController = TextEditingController();
+  final _displayNameController = TextEditingController();
+  final _valueTextController = TextEditingController();
 
   late String _selectedFieldCategory;
-  late String _selectedFieldType;
-  late bool _isRequired;
+  String _selectedFieldType = 'text';
+  bool _isRequired = false;
   bool _isLoading = false;
   bool _checkboxValue = false;
 
-  // Extended categories and names to include new categories created during editing
+  // Extended categories and names to include new categories created during adding
   late List<String> _currentCategories;
   late Map<String, String> _currentCategoryNames;
 
@@ -184,32 +234,23 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
   @override
   void initState() {
     super.initState();
-    _fieldNameController = TextEditingController(text: widget.field.fieldName);
-    _displayNameController = TextEditingController(text: widget.field.displayName);
-    _valueTextController = TextEditingController(text: widget.field.currentValue);
 
+    // Initialize current categories from widget
     _currentCategories = List.from(widget.categories);
     _currentCategoryNames = Map.from(widget.categoryNames);
 
-    // Keep the field's original category if it exists, otherwise use first available
-    if (widget.categories.contains(widget.field.category)) {
-      _selectedFieldCategory = widget.field.category;
-    } else if (widget.categories.isNotEmpty) {
-      _selectedFieldCategory = widget.categories.first;
+    // Select pre-selected category if provided, otherwise first available category
+    if (widget.preSelectedCategory != null &&
+        _currentCategories.contains(widget.preSelectedCategory!)) {
+      _selectedFieldCategory = widget.preSelectedCategory!;
+    } else if (_currentCategories.isNotEmpty) {
+      _selectedFieldCategory = _currentCategories.first;
     } else {
-      // This shouldn't happen, but fallback to the original category
-      _selectedFieldCategory = widget.field.category;
+      _selectedFieldCategory = '';
     }
+    _valueTextController.text = 'false';
 
-    _selectedFieldType = widget.field.fieldType;
-    _isRequired = widget.field.isRequired;
-
-    // Initialize checkbox state if it's a checkbox field
-    if (_selectedFieldType == 'checkbox') {
-      _checkboxValue = widget.field.currentValue.toLowerCase() == 'true';
-    }
-
-    debugPrint('🔧 Editing field: ${widget.field.fieldName} in category: $_selectedFieldCategory');
+    debugPrint('🎯 AddFieldDialog initialized with category: $_selectedFieldCategory');
   }
 
   @override
@@ -235,23 +276,22 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
             // Header
             Container(
               padding: const EdgeInsets.fromLTRB(20, 16, 16, 8),
-              decoration: BoxDecoration(
+              decoration: const BoxDecoration(
                 color: RufkoTheme.primaryColor,
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
+                borderRadius: BorderRadius.vertical(top: Radius.circular(4)),
               ),
               child: Row(
                 children: [
-                  const Icon(Icons.edit, color: Colors.white, size: 20),
+                  const Icon(Icons.add_circle, color: Colors.white, size: 20),
                   const SizedBox(width: 8),
-                  Expanded(
+                  const Expanded(
                     child: Text(
-                      'Edit: ${widget.field.displayName}',
-                      style: const TextStyle(
+                      'Add Field',
+                      style: TextStyle(
                         color: Colors.white,
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
                       ),
-                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
                   IconButton(
@@ -318,7 +358,7 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                         onChanged: (String? newValue) async {
                           if (newValue == _createNewCategoryValue) {
                             // Show create category dialog
-                            final newCategory = await EditCustomFieldDialog._createNewCategoryAndReturn(context);
+                            final newCategory = await AddFieldDialog._createNewCategoryAndReturn(context);
                             if (newCategory != null && mounted) {
                               // Update the local categories and select the new one
                               final appState = context.read<AppStateProvider>();
@@ -375,10 +415,6 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                           if (newValue != null) {
                             setState(() {
                               _selectedFieldType = newValue;
-                              // Reset checkbox value when type changes
-                              if (newValue == 'checkbox') {
-                                _checkboxValue = _valueTextController.text.toLowerCase() == 'true';
-                              }
                             });
                           }
                         },
@@ -397,17 +433,20 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                           border: OutlineInputBorder(),
                         ),
                         style: const TextStyle(fontSize: 14),
+                        onChanged: (value) {
+                          if (_displayNameController.text.isEmpty ||
+                              _displayNameController.text == _generateDisplayName(_fieldNameController.text)) {
+                            _displayNameController.text = _generateDisplayName(value);
+                          }
+                        },
                         validator: (value) {
                           if (value == null || value.isEmpty) return 'Enter field name';
                           if (value.contains(' ')) return 'No spaces allowed';
 
                           final appState = context.read<AppStateProvider>();
-                          if (value.trim() != widget.field.fieldName &&
-                              appState.customAppDataFields.any((f) =>
-                              f.fieldName == value.trim() &&
-                                  f.category == _selectedFieldCategory &&
-                                  f.id != widget.field.id)) {
-                            return 'Name already exists';
+                          if (appState.customAppDataFields.any((f) =>
+                          f.fieldName == value.trim() && f.category == _selectedFieldCategory)) {
+                            return 'Name already exists in this category';
                           }
                           return null;
                         },
@@ -434,71 +473,74 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                       ),
                       const SizedBox(height: 12),
 
-                      // Current Value - Different UI for checkbox vs other types
-                      if (_selectedFieldType == 'checkbox') ...[
-                        Container(
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey.shade400),
-                            borderRadius: BorderRadius.circular(4),
+                      ExpansionTile(
+                        tilePadding: EdgeInsets.zero,
+                        title: const Text('Advanced Options', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                        children: [
+                          const SizedBox(height: 8),
+                          if (_selectedFieldType == 'checkbox')
+                            Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(color: Colors.grey.shade400),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: CheckboxListTile(
+                                title: const Text('Default State', style: TextStyle(fontSize: 14)),
+                                subtitle: const Text('Initial checkbox value', style: TextStyle(fontSize: 12)),
+                                value: _checkboxValue,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    _checkboxValue = value ?? false;
+                                    _valueTextController.text = _checkboxValue.toString();
+                                  });
+                                },
+                                controlAffinity: ListTileControlAffinity.leading,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                              ),
+                            )
+                          else
+                            TextFormField(
+                              controller: _valueTextController,
+                              decoration: const InputDecoration(
+                                labelText: 'Default Value',
+                                hintText: 'Enter default value',
+                                isDense: true,
+                                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                border: OutlineInputBorder(),
+                              ),
+                              style: const TextStyle(fontSize: 14),
+                              maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
+                              keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
+                              _selectedFieldType == 'email' ? TextInputType.emailAddress :
+                              _selectedFieldType == 'phone' ? TextInputType.phone :
+                              TextInputType.text,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Enter default value';
+                                }
+                                return null;
+                              },
+                            ),
+                          const SizedBox(height: 12),
+                          Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(color: Colors.grey.shade300),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: CheckboxListTile(
+                              title: const Text('Required Field', style: TextStyle(fontSize: 14)),
+                              subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
+                              value: _isRequired,
+                              onChanged: (bool? value) {
+                                setState(() {
+                                  _isRequired = value ?? false;
+                                });
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                            ),
                           ),
-                          child: CheckboxListTile(
-                            title: const Text('Current State', style: TextStyle(fontSize: 14)),
-                            subtitle: const Text('Current checkbox value', style: TextStyle(fontSize: 12)),
-                            value: _checkboxValue,
-                            onChanged: (bool? value) {
-                              setState(() {
-                                _checkboxValue = value ?? false;
-                                _valueTextController.text = _checkboxValue.toString();
-                              });
-                            },
-                            controlAffinity: ListTileControlAffinity.leading,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                        ),
-                      ] else ...[
-                        TextFormField(
-                          controller: _valueTextController,
-                          decoration: const InputDecoration(
-                            labelText: 'Current Value',
-                            hintText: 'Enter current value',
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                            border: OutlineInputBorder(),
-                          ),
-                          style: const TextStyle(fontSize: 14),
-                          maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
-                          keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
-                          _selectedFieldType == 'email' ? TextInputType.emailAddress :
-                          _selectedFieldType == 'phone' ? TextInputType.phone :
-                          TextInputType.text,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Enter current value';
-                            }
-                            return null;
-                          },
-                        ),
-                      ],
-                      const SizedBox(height: 12),
-
-                      // Required checkbox - compact
-                      Container(
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey.shade300),
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: CheckboxListTile(
-                          title: const Text('Required Field', style: TextStyle(fontSize: 14)),
-                          subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
-                          value: _isRequired,
-                          onChanged: (bool? value) {
-                            setState(() {
-                              _isRequired = value ?? false;
-                            });
-                          },
-                          controlAffinity: ListTileControlAffinity.leading,
-                          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                        ),
+                        ],
                       ),
                     ],
                   ),
@@ -521,7 +563,7 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
-                    onPressed: _isLoading ? null : _handleSaveChanges,
+                    onPressed: _isLoading ? null : _handleAddField,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: RufkoTheme.primaryColor,
                       foregroundColor: Colors.white,
@@ -536,7 +578,7 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
                         valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                       ),
                     )
-                        : const Text('Save'),
+                        : const Text('Add Field'),
                   ),
                 ],
               ),
@@ -547,7 +589,17 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
     );
   }
 
-  Future<void> _handleSaveChanges() async {
+  String _generateDisplayName(String fieldName) {
+    return fieldName
+        .replaceAll('_', ' ')
+        .split(' ')
+        .map((word) => word.isNotEmpty
+        ? '${word[0].toUpperCase()}${word.substring(1)}'
+        : '')
+        .join(' ');
+  }
+
+  Future<void> _handleAddField() async {
     if (!_formKey.currentState!.validate()) {
       return;
     }
@@ -557,32 +609,28 @@ class _EditCustomFieldDialogState extends State<EditCustomFieldDialog>
     });
 
     try {
-      debugPrint('💾 Saving field with category: $_selectedFieldCategory');
+      debugPrint('🚀 Creating field with category: $_selectedFieldCategory');
 
-      final updatedField = CustomAppDataField(
-        id: widget.field.id,
+      final newFieldData = CustomAppDataField(
         fieldName: _fieldNameController.text.trim(),
         displayName: _displayNameController.text.trim(),
         fieldType: _selectedFieldType,
         category: _selectedFieldCategory,
         currentValue: _valueTextController.text.trim(),
-        placeholder: null, // Removed as requested
-        description: null, // Removed as requested
+        placeholder: null,
+        description: null,
         isRequired: _isRequired,
-        sortOrder: widget.field.sortOrder,
-        createdAt: widget.field.createdAt,
-        updatedAt: DateTime.now(),
       );
 
-      debugPrint('💾 Updated field: ${updatedField.fieldName} in category: ${updatedField.category}');
-      Navigator.of(context).pop(updatedField);
+      debugPrint('🆕 Created field: ${newFieldData.fieldName} in category: ${newFieldData.category}');
+      Navigator.of(context).pop(newFieldData);
     } catch (e) {
-      debugPrint('❌ Error in edit field dialog: $e');
+      debugPrint('❌ Error in add field dialog: $e');
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Error saving field: $e'),
+            content: Text('Error adding field: $e'),
             backgroundColor: Colors.red,
           ),
         );

--- a/lib/widgets/templates/dialgos/edit_field_dialog.dart
+++ b/lib/widgets/templates/dialgos/edit_field_dialog.dart
@@ -1,4 +1,4 @@
-// lib/widgets/add_custom_field_dialog.dart
+// lib/widgets/edit_field_dialog.dart
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -7,69 +7,19 @@ import '../../../providers/app_state_provider.dart';
 import '../../../mixins/field_type_mixin.dart';
 import '../../../theme/rufko_theme.dart';
 
-class AddCustomFieldDialog extends StatefulWidget {
+class EditFieldDialog extends StatefulWidget {
+  final CustomAppDataField field;
   final List<String> categories;
   final Map<String, String> categoryNames;
-  final String? preSelectedCategory;
 
-  const AddCustomFieldDialog({
+  const EditFieldDialog({
     super.key,
+    required this.field,
     required this.categories,
     required this.categoryNames,
-    this.preSelectedCategory,
   });
 
-  // Static method to show dialog with category check
-  static Future<CustomAppDataField?> show(BuildContext context, {String? preSelectedCategory}) async {
-    final appState = context.read<AppStateProvider>();
-
-    // Get available categories for custom fields
-    final allTemplateCategories = appState.templateCategories;
-    final customFieldCategories = allTemplateCategories
-        .where((cat) => cat.templateType == 'custom_fields')
-        .toList();
-
-    // If no categories exist, prompt to create one
-    if (customFieldCategories.isEmpty) {
-      final newCategory = await _createNewCategoryAndReturn(context);
-      if (newCategory == null) return null; // User cancelled
-
-      // Reload categories after creation
-      await appState.loadTemplateCategories();
-      final updatedCategories = appState.templateCategories
-          .where((cat) => cat.templateType == 'custom_fields')
-          .toList();
-
-      if (updatedCategories.isEmpty) return null; // Still no categories
-      preSelectedCategory = newCategory; // Select the newly created category
-    }
-
-    // Now show the field dialog
-    final finalCategories = appState.templateCategories
-        .where((cat) => cat.templateType == 'custom_fields')
-        .toList();
-
-    final availableCategories = <String>[];
-    final categoryNames = <String, String>{};
-
-    for (final category in finalCategories) {
-      availableCategories.add(category.key);
-      categoryNames[category.key] = category.name;
-    }
-
-    return showDialog<CustomAppDataField?>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
-        return AddCustomFieldDialog(
-          categories: availableCategories,
-          categoryNames: categoryNames,
-          preSelectedCategory: preSelectedCategory,
-        );
-      },
-    );
-  }
-
+  // Static method to create a new category
   static Future<String?> _createNewCategoryAndReturn(BuildContext context) async {
     final TextEditingController controller = TextEditingController();
 
@@ -103,8 +53,8 @@ class AddCustomFieldDialog extends StatefulWidget {
                             color: Colors.white,
                             fontSize: 16,
                             fontWeight: FontWeight.bold,
-                          ),
                         ),
+                      ),
                       ),
                       IconButton(
                         onPressed: () => Navigator.of(context).pop(),
@@ -123,7 +73,7 @@ class AddCustomFieldDialog extends StatefulWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const Text(
-                        'Create a new category for custom fields:',
+                        'Create a new category for fields:',
                         style: TextStyle(fontSize: 14, color: Colors.grey),
                       ),
                       const SizedBox(height: 16),
@@ -208,23 +158,23 @@ class AddCustomFieldDialog extends StatefulWidget {
   }
 
   @override
-  State<AddCustomFieldDialog> createState() => _AddCustomFieldDialogState();
+  State<EditFieldDialog> createState() => _EditFieldDialogState();
 }
 
-class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
+class _EditFieldDialogState extends State<EditFieldDialog>
     with FieldTypeMixin {
   final _formKey = GlobalKey<FormState>();
-  final _fieldNameController = TextEditingController();
-  final _displayNameController = TextEditingController();
-  final _valueTextController = TextEditingController();
+  late final TextEditingController _fieldNameController;
+  late final TextEditingController _displayNameController;
+  late final TextEditingController _valueTextController;
 
   late String _selectedFieldCategory;
-  String _selectedFieldType = 'text';
-  bool _isRequired = false;
+  late String _selectedFieldType;
+  late bool _isRequired;
   bool _isLoading = false;
   bool _checkboxValue = false;
 
-  // Extended categories and names to include new categories created during adding
+  // Extended categories and names to include new categories created during editing
   late List<String> _currentCategories;
   late Map<String, String> _currentCategoryNames;
 
@@ -234,23 +184,32 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
   @override
   void initState() {
     super.initState();
+    _fieldNameController = TextEditingController(text: widget.field.fieldName);
+    _displayNameController = TextEditingController(text: widget.field.displayName);
+    _valueTextController = TextEditingController(text: widget.field.currentValue);
 
-    // Initialize current categories from widget
     _currentCategories = List.from(widget.categories);
     _currentCategoryNames = Map.from(widget.categoryNames);
 
-    // Select pre-selected category if provided, otherwise first available category
-    if (widget.preSelectedCategory != null &&
-        _currentCategories.contains(widget.preSelectedCategory!)) {
-      _selectedFieldCategory = widget.preSelectedCategory!;
-    } else if (_currentCategories.isNotEmpty) {
-      _selectedFieldCategory = _currentCategories.first;
+    // Keep the field's original category if it exists, otherwise use first available
+    if (widget.categories.contains(widget.field.category)) {
+      _selectedFieldCategory = widget.field.category;
+    } else if (widget.categories.isNotEmpty) {
+      _selectedFieldCategory = widget.categories.first;
     } else {
-      _selectedFieldCategory = '';
+      // This shouldn't happen, but fallback to the original category
+      _selectedFieldCategory = widget.field.category;
     }
-    _valueTextController.text = 'false';
 
-    debugPrint('🎯 AddCustomFieldDialog initialized with category: $_selectedFieldCategory');
+    _selectedFieldType = widget.field.fieldType;
+    _isRequired = widget.field.isRequired;
+
+    // Initialize checkbox state if it's a checkbox field
+    if (_selectedFieldType == 'checkbox') {
+      _checkboxValue = widget.field.currentValue.toLowerCase() == 'true';
+    }
+
+    debugPrint('🔧 Editing field: ${widget.field.fieldName} in category: $_selectedFieldCategory');
   }
 
   @override
@@ -276,22 +235,23 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
             // Header
             Container(
               padding: const EdgeInsets.fromLTRB(20, 16, 16, 8),
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 color: RufkoTheme.primaryColor,
-                borderRadius: BorderRadius.vertical(top: Radius.circular(4)),
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
               ),
               child: Row(
                 children: [
-                  const Icon(Icons.add_circle, color: Colors.white, size: 20),
+                  const Icon(Icons.edit, color: Colors.white, size: 20),
                   const SizedBox(width: 8),
-                  const Expanded(
+                  Expanded(
                     child: Text(
-                      'Add Field',
-                      style: TextStyle(
+                      'Edit: ${widget.field.displayName}',
+                      style: const TextStyle(
                         color: Colors.white,
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
                       ),
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
                   IconButton(
@@ -358,7 +318,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                         onChanged: (String? newValue) async {
                           if (newValue == _createNewCategoryValue) {
                             // Show create category dialog
-                            final newCategory = await AddCustomFieldDialog._createNewCategoryAndReturn(context);
+                            final newCategory = await EditFieldDialog._createNewCategoryAndReturn(context);
                             if (newCategory != null && mounted) {
                               // Update the local categories and select the new one
                               final appState = context.read<AppStateProvider>();
@@ -415,6 +375,10 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                           if (newValue != null) {
                             setState(() {
                               _selectedFieldType = newValue;
+                              // Reset checkbox value when type changes
+                              if (newValue == 'checkbox') {
+                                _checkboxValue = _valueTextController.text.toLowerCase() == 'true';
+                              }
                             });
                           }
                         },
@@ -433,20 +397,17 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                           border: OutlineInputBorder(),
                         ),
                         style: const TextStyle(fontSize: 14),
-                        onChanged: (value) {
-                          if (_displayNameController.text.isEmpty ||
-                              _displayNameController.text == _generateDisplayName(_fieldNameController.text)) {
-                            _displayNameController.text = _generateDisplayName(value);
-                          }
-                        },
                         validator: (value) {
                           if (value == null || value.isEmpty) return 'Enter field name';
                           if (value.contains(' ')) return 'No spaces allowed';
 
                           final appState = context.read<AppStateProvider>();
-                          if (appState.customAppDataFields.any((f) =>
-                          f.fieldName == value.trim() && f.category == _selectedFieldCategory)) {
-                            return 'Name already exists in this category';
+                          if (value.trim() != widget.field.fieldName &&
+                              appState.customAppDataFields.any((f) =>
+                              f.fieldName == value.trim() &&
+                                  f.category == _selectedFieldCategory &&
+                                  f.id != widget.field.id)) {
+                            return 'Name already exists';
                           }
                           return null;
                         },
@@ -473,71 +434,74 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                       ),
                       const SizedBox(height: 12),
 
-                      // Current Value - Different UI for checkbox vs other types
-                      if (_selectedFieldType == 'checkbox') ...[
-                        Container(
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey.shade400),
-                            borderRadius: BorderRadius.circular(4),
+                      ExpansionTile(
+                        tilePadding: EdgeInsets.zero,
+                        title: const Text('Advanced Options', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                        children: [
+                          const SizedBox(height: 8),
+                          if (_selectedFieldType == 'checkbox')
+                            Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(color: Colors.grey.shade400),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: CheckboxListTile(
+                                title: const Text('Current State', style: TextStyle(fontSize: 14)),
+                                subtitle: const Text('Current checkbox value', style: TextStyle(fontSize: 12)),
+                                value: _checkboxValue,
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    _checkboxValue = value ?? false;
+                                    _valueTextController.text = _checkboxValue.toString();
+                                  });
+                                },
+                                controlAffinity: ListTileControlAffinity.leading,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                              ),
+                            )
+                          else
+                            TextFormField(
+                              controller: _valueTextController,
+                              decoration: const InputDecoration(
+                                labelText: 'Current Value',
+                                hintText: 'Enter current value',
+                                isDense: true,
+                                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                border: OutlineInputBorder(),
+                              ),
+                              style: const TextStyle(fontSize: 14),
+                              maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
+                              keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
+                              _selectedFieldType == 'email' ? TextInputType.emailAddress :
+                              _selectedFieldType == 'phone' ? TextInputType.phone :
+                              TextInputType.text,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Enter current value';
+                                }
+                                return null;
+                              },
+                            ),
+                          const SizedBox(height: 12),
+                          Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(color: Colors.grey.shade300),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: CheckboxListTile(
+                              title: const Text('Required Field', style: TextStyle(fontSize: 14)),
+                              subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
+                              value: _isRequired,
+                              onChanged: (bool? value) {
+                                setState(() {
+                                  _isRequired = value ?? false;
+                                });
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                            ),
                           ),
-                          child: CheckboxListTile(
-                            title: const Text('Default State', style: TextStyle(fontSize: 14)),
-                            subtitle: const Text('Initial checkbox value', style: TextStyle(fontSize: 12)),
-                            value: _checkboxValue,
-                            onChanged: (bool? value) {
-                              setState(() {
-                                _checkboxValue = value ?? false;
-                                _valueTextController.text = _checkboxValue.toString();
-                              });
-                            },
-                            controlAffinity: ListTileControlAffinity.leading,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                        ),
-                      ] else ...[
-                        TextFormField(
-                          controller: _valueTextController,
-                          decoration: const InputDecoration(
-                            labelText: 'Default Value',
-                            hintText: 'Enter default value',
-                            isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                            border: OutlineInputBorder(),
-                          ),
-                          style: const TextStyle(fontSize: 14),
-                          maxLines: _selectedFieldType == 'multiline' ? 2 : 1,
-                          keyboardType: _selectedFieldType == 'number' ? TextInputType.number :
-                          _selectedFieldType == 'email' ? TextInputType.emailAddress :
-                          _selectedFieldType == 'phone' ? TextInputType.phone :
-                          TextInputType.text,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Enter default value';
-                            }
-                            return null;
-                          },
-                        ),
-                      ],
-                      const SizedBox(height: 12),
-
-                      // Required checkbox - compact
-                      Container(
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey.shade300),
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: CheckboxListTile(
-                          title: const Text('Required Field', style: TextStyle(fontSize: 14)),
-                          subtitle: const Text('Must be filled for PDFs', style: TextStyle(fontSize: 12)),
-                          value: _isRequired,
-                          onChanged: (bool? value) {
-                            setState(() {
-                              _isRequired = value ?? false;
-                            });
-                          },
-                          controlAffinity: ListTileControlAffinity.leading,
-                          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                        ),
+                        ],
                       ),
                     ],
                   ),
@@ -560,7 +524,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
-                    onPressed: _isLoading ? null : _handleAddField,
+                    onPressed: _isLoading ? null : _handleSaveChanges,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: RufkoTheme.primaryColor,
                       foregroundColor: Colors.white,
@@ -575,7 +539,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
                         valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                       ),
                     )
-                        : const Text('Add Field'),
+                        : const Text('Save'),
                   ),
                 ],
               ),
@@ -586,17 +550,7 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
     );
   }
 
-  String _generateDisplayName(String fieldName) {
-    return fieldName
-        .replaceAll('_', ' ')
-        .split(' ')
-        .map((word) => word.isNotEmpty
-        ? '${word[0].toUpperCase()}${word.substring(1)}'
-        : '')
-        .join(' ');
-  }
-
-  Future<void> _handleAddField() async {
+  Future<void> _handleSaveChanges() async {
     if (!_formKey.currentState!.validate()) {
       return;
     }
@@ -606,28 +560,32 @@ class _AddCustomFieldDialogState extends State<AddCustomFieldDialog>
     });
 
     try {
-      debugPrint('🚀 Creating field with category: $_selectedFieldCategory');
+      debugPrint('💾 Saving field with category: $_selectedFieldCategory');
 
-      final newFieldData = CustomAppDataField(
+      final updatedField = CustomAppDataField(
+        id: widget.field.id,
         fieldName: _fieldNameController.text.trim(),
         displayName: _displayNameController.text.trim(),
         fieldType: _selectedFieldType,
         category: _selectedFieldCategory,
         currentValue: _valueTextController.text.trim(),
-        placeholder: null,
-        description: null,
+        placeholder: null, // Removed as requested
+        description: null, // Removed as requested
         isRequired: _isRequired,
+        sortOrder: widget.field.sortOrder,
+        createdAt: widget.field.createdAt,
+        updatedAt: DateTime.now(),
       );
 
-      debugPrint('🆕 Created field: ${newFieldData.fieldName} in category: ${newFieldData.category}');
-      Navigator.of(context).pop(newFieldData);
+      debugPrint('💾 Updated field: ${updatedField.fieldName} in category: ${updatedField.category}');
+      Navigator.of(context).pop(updatedField);
     } catch (e) {
-      debugPrint('❌ Error in add field dialog: $e');
+      debugPrint('❌ Error in edit field dialog: $e');
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Error adding field: $e'),
+            content: Text('Error saving field: $e'),
             backgroundColor: Colors.red,
           ),
         );

--- a/lib/widgets/templates/fields_tab.dart
+++ b/lib/widgets/templates/fields_tab.dart
@@ -2,20 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/custom_app_data.dart';
 import '../../providers/app_state_provider.dart';
-import 'dialgos/add_custom_field_dialog.dart';
-import 'dialgos/edit_custom_field_dialog.dart';
+import 'dialgos/add_field_dialog.dart';
+import 'dialgos/edit_field_dialog.dart';
 import '../../utils/common_utils.dart';
 import '../../theme/rufko_theme.dart';
 import '../../mixins/template_tab_mixin.dart';
 
-class CustomAppDataScreen extends StatefulWidget {
-  const CustomAppDataScreen({super.key});
+class FieldsTab extends StatefulWidget {
+  const FieldsTab({super.key});
 
   @override
-  State<CustomAppDataScreen> createState() => _CustomAppDataScreenState();
+  State<FieldsTab> createState() => _FieldsTabState();
 }
 
-class _CustomAppDataScreenState extends State<CustomAppDataScreen> with TemplateTabMixin {
+class _FieldsTabState extends State<FieldsTab> with TemplateTabMixin {
 
   // Implement required mixin properties
   @override
@@ -267,7 +267,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
     return Scaffold(
       backgroundColor: Colors.grey[50],
       appBar: AppBar(
-        title: const Text('Custom App Data'),
+        title: const Text('Fields'),
         backgroundColor: RufkoTheme.primaryColor,
         foregroundColor: Colors.white,
         elevation: 0,
@@ -292,7 +292,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
     );
   }
 
-  // Field-specific helper methods (these are unique to custom fields)
+  // Field-specific helper methods (these are unique to fields)
   Color _getFieldTypeColor(String fieldType) {
     switch (fieldType) {
       case 'text': return Colors.blue;
@@ -358,7 +358,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
               categoryNames[categoryKey] = categoryName;
             }
 
-            return AddCustomFieldDialog(
+            return AddFieldDialog(
               categories: availableCategories,
               categoryNames: categoryNames,
             );
@@ -414,7 +414,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
               }
             }
 
-            return EditCustomFieldDialog(
+            return EditFieldDialog(
               field: field,
               categories: availableCategories,
               categoryNames: categoryNames,
@@ -457,7 +457,7 @@ class _CustomAppDataScreenState extends State<CustomAppDataScreen> with Template
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title: const Text('Delete Custom Field'),
+          title: const Text('Delete Field'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- rename custom fields files to use simpler "field" naming
- collapse advanced options for default value and required state
- add help button in field mapping screen for guidance
- wire new dialog and tab names across the app
- fix syntax errors and clean up unused imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846316b9138832ca99d5f670c51b758