### PR TITLE
Add product image support and improve small-screen UI

### DIFF
--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -117,6 +117,10 @@ class Product extends HiveObject {
   @HiveField(18)
   ProductPricingType pricingType; // mainDifferentiator,  subLeveled, simple
 
+  // Optional path to a product image
+  @HiveField(19)
+  String? imagePath;
+
   Product({
     String? id,
     required this.name,
@@ -137,6 +141,7 @@ class Product extends HiveObject {
     ProductPricingType? pricingType, // NEW
     DateTime? createdAt,
     DateTime? updatedAt,
+    this.imagePath,
   })  : levelPrices = levelPrices ?? {},
         enhancedLevelPrices = enhancedLevelPrices ?? [],
         pricingType = pricingType ?? ProductPricingType.simple, // NEW
@@ -237,6 +242,7 @@ class Product extends HiveObject {
     String? notes,
     bool? isMainDifferentiator, // NEW
     bool? enableLevelPricing, // NEW
+    String? imagePath,
   }) {
     if (name != null) this.name = name;
     if (description != null) this.description = description;
@@ -253,6 +259,7 @@ class Product extends HiveObject {
     if (isDiscountable != null) this.isDiscountable = isDiscountable;
     if (maxLevels != null) this.maxLevels = maxLevels;
     if (notes != null) this.notes = notes;
+    if (imagePath != null) this.imagePath = imagePath;
 
     // NEW: Update 3-tier system flags
     if (isMainDifferentiator != null) this.isMainDifferentiator = isMainDifferentiator;
@@ -297,6 +304,7 @@ class Product extends HiveObject {
       'pricingType': pricingType.toString(), // NEW
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
+      'imagePath': imagePath,
     };
   }
 
@@ -326,6 +334,7 @@ class Product extends HiveObject {
       ), // NEW
       createdAt: DateTime.parse(map['createdAt']),
       updatedAt: DateTime.parse(map['updatedAt']),
+      imagePath: map['imagePath'],
     );
   }
 

--- a/lib/models/product.g.dart
+++ b/lib/models/product.g.dart
@@ -82,13 +82,14 @@ class ProductAdapter extends TypeAdapter<Product> {
       pricingType: fields[18] as ProductPricingType?,
       createdAt: fields[8] as DateTime?,
       updatedAt: fields[9] as DateTime?,
+      imagePath: fields[19] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, Product obj) {
     writer
-      ..writeByte(19)
+      ..writeByte(20)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -126,7 +127,9 @@ class ProductAdapter extends TypeAdapter<Product> {
       ..writeByte(17)
       ..write(obj.enableLevelPricing)
       ..writeByte(18)
-      ..write(obj.pricingType);
+      ..write(obj.pricingType)
+      ..writeByte(19)
+      ..write(obj.imagePath);
   }
 
   @override

--- a/lib/screens/products/product_form_dialog.dart
+++ b/lib/screens/products/product_form_dialog.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'dart:io';
+
+import '../../services/file_service.dart';
 
 import '../../models/product.dart';
 import '../../providers/app_state_provider.dart';
@@ -25,6 +28,8 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
   String _selectedUnit = 'each';
   bool _isActive = true;
   bool _isDiscountable = true;
+
+  String? _imagePath;
 
   // 3-Tier System State
   ProductPricingType _pricingType = ProductPricingType.simple;
@@ -174,6 +179,35 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              Center(
+                child: Column(
+                  children: [
+                    GestureDetector(
+                      onTap: _pickImage,
+                      child: CircleAvatar(
+                        radius: isPhone ? 40 : 50,
+                        backgroundImage:
+                            _imagePath != null ? FileImage(File(_imagePath!)) : null,
+                        child: _imagePath == null
+                            ? Icon(Icons.camera_alt,
+                                size: isPhone ? 24 : 32,
+                                color: Colors.grey)
+                            : null,
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: _pickImage,
+                      child: Text(_imagePath == null ? 'Add Photo' : 'Change Photo'),
+                    ),
+                    if (_imagePath != null)
+                      TextButton(
+                        onPressed: () => setState(() => _imagePath = null),
+                        child: const Text('Remove Photo'),
+                      ),
+                  ],
+                ),
+              ),
+              SizedBox(height: isPhone ? 20 : 24),
               _buildModernTextField(
                 controller: _nameController,
                 label: 'Product Name',
@@ -1069,6 +1103,7 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
       _isDiscountable = p.isDiscountable;
       _pricingType = p.pricingType;
       _isMainDifferentiator = p.isMainDifferentiator;
+      _imagePath = p.imagePath;
 
       _currentLevelKeys = p.enhancedLevelPrices.map((level) => level.levelId).toList();
       if (_currentLevelKeys.isEmpty && _pricingType != ProductPricingType.simple) {
@@ -1121,6 +1156,14 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
     }
   }
 
+  Future<void> _pickImage() async {
+    final path = await FileService.instance.pickAndSaveProductImage();
+    if (!mounted) return;
+    if (path != null) {
+      setState(() => _imagePath = path);
+    }
+  }
+
   void _saveProduct() {
     if (!_formKey.currentState!.validate()) {
       if (_nameController.text.isEmpty || _basePriceController.text.isEmpty) {
@@ -1166,6 +1209,7 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
         isDiscountable: _isDiscountable,
         isMainDifferentiator: _isMainDifferentiator,
         enableLevelPricing: _pricingType != ProductPricingType.simple,
+        imagePath: _imagePath,
       );
 
       widget.product!.enhancedLevelPrices.clear();
@@ -1190,6 +1234,7 @@ class _ProductFormDialogState extends State<ProductFormDialog> with TickerProvid
         enableLevelPricing: _pricingType != ProductPricingType.simple,
         pricingType: _pricingType,
         enhancedLevelPrices: enhancedLevelPrices,
+        imagePath: _imagePath,
       );
 
       appState.addProduct(newProduct);

--- a/lib/screens/products_screen.dart
+++ b/lib/screens/products_screen.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'dart:io';
 import '../providers/app_state_provider.dart';
 import '../models/product.dart';
 import 'products/product_form_dialog.dart';
@@ -176,6 +177,8 @@ class _ProductsScreenState extends State<ProductsScreen>
   Widget _buildProductsList(AppStateProvider appState, String categoryFilter) {
     List<Product> productsToDisplay = _getFilteredProducts(appState, categoryFilter);
 
+    final isSmallScreen = MediaQuery.of(context).size.width < 360;
+
     if (productsToDisplay.isEmpty) {
       return _buildEmptyState(categoryFilter);
     }
@@ -183,19 +186,19 @@ class _ProductsScreenState extends State<ProductsScreen>
     return RefreshIndicator(
       onRefresh: () => appState.loadAllData(),
       child: ListView.builder(
-        padding: const EdgeInsets.all(16),
+        padding: EdgeInsets.all(isSmallScreen ? 8 : 16),
         itemCount: productsToDisplay.length,
         itemBuilder: (context, index) {
           final product = productsToDisplay[index];
-          return _buildProductCard(product);
+          return _buildProductCard(product, isSmallScreen);
         },
       ),
     );
   }
 
-  Widget _buildProductCard(Product product) {
+  Widget _buildProductCard(Product product, bool isSmall) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 12),
+      margin: EdgeInsets.only(bottom: isSmall ? 8 : 12),
       child: Card(
         elevation: 2,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
@@ -203,27 +206,38 @@ class _ProductsScreenState extends State<ProductsScreen>
           onTap: () => _showProductDetails(product),
           borderRadius: BorderRadius.circular(12),
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.all(isSmall ? 12 : 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(
                   children: [
-                    // Product Icon
-                    Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        color: _getCategoryColor(product.category).withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(12),
+                    // Product Icon or Image
+                    if (product.imagePath != null)
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.file(
+                          File(product.imagePath!),
+                          width: isSmall ? 40 : 48,
+                          height: isSmall ? 40 : 48,
+                          fit: BoxFit.cover,
+                        ),
+                      )
+                    else
+                      Container(
+                        width: isSmall ? 40 : 48,
+                        height: isSmall ? 40 : 48,
+                        decoration: BoxDecoration(
+                          color: _getCategoryColor(product.category).withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Icon(
+                          _getCategoryIcon(product.category),
+                          color: _getCategoryColor(product.category),
+                          size: isSmall ? 20 : 24,
+                        ),
                       ),
-                      child: Icon(
-                        _getCategoryIcon(product.category),
-                        color: _getCategoryColor(product.category),
-                        size: 24,
-                      ),
-                    ),
-                    const SizedBox(width: 16),
+                    SizedBox(width: isSmall ? 12 : 16),
 
                     // Product Info
                     Expanded(
@@ -235,14 +249,14 @@ class _ProductsScreenState extends State<ProductsScreen>
                               Expanded(
                                 child: Text(
                                   product.name,
-                                  style: const TextStyle(
-                                    fontSize: 16,
+                                  style: TextStyle(
+                                    fontSize: isSmall ? 14 : 16,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
                               ),
                               Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                padding: EdgeInsets.symmetric(horizontal: isSmall ? 6 : 8, vertical: 4),
                                 decoration: BoxDecoration(
                                   color: product.isActive ? Colors.green.shade100 : Colors.grey.shade200,
                                   borderRadius: BorderRadius.circular(12),
@@ -250,7 +264,7 @@ class _ProductsScreenState extends State<ProductsScreen>
                                 child: Text(
                                   product.isActive ? 'Active' : 'Inactive',
                                   style: TextStyle(
-                                    fontSize: 12,
+                                    fontSize: isSmall ? 10 : 12,
                                     fontWeight: FontWeight.w500,
                                     color: product.isActive ? Colors.green.shade700 : Colors.grey.shade600,
                                   ),
@@ -263,7 +277,7 @@ class _ProductsScreenState extends State<ProductsScreen>
                           Row(
                             children: [
                               Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                                padding: EdgeInsets.symmetric(horizontal: isSmall ? 4 : 6, vertical: 2),
                                 decoration: BoxDecoration(
                                   color: _getCategoryColor(product.category).withValues(alpha: 0.1),
                                   borderRadius: BorderRadius.circular(6),
@@ -271,17 +285,17 @@ class _ProductsScreenState extends State<ProductsScreen>
                                 child: Text(
                                   product.category,
                                   style: TextStyle(
-                                    fontSize: 11,
+                                    fontSize: isSmall ? 10 : 11,
                                     fontWeight: FontWeight.w500,
                                     color: _getCategoryColor(product.category),
                                   ),
                                 ),
                               ),
-                              const SizedBox(width: 8),
+                              SizedBox(width: isSmall ? 6 : 8),
                               Text(
                                 '\$${product.unitPrice.toStringAsFixed(2)}/${product.unit}',
                                 style: TextStyle(
-                                  fontSize: 14,
+                                  fontSize: isSmall ? 12 : 14,
                                   fontWeight: FontWeight.w600,
                                   color: Colors.grey[700],
                                 ),
@@ -290,11 +304,11 @@ class _ProductsScreenState extends State<ProductsScreen>
                           ),
 
                           if (product.description != null && product.description!.isNotEmpty) ...[
-                            const SizedBox(height: 4),
+                            SizedBox(height: isSmall ? 2 : 4),
                             Text(
                               product.description!,
                               style: TextStyle(
-                                fontSize: 13,
+                                fontSize: isSmall ? 11 : 13,
                                 color: Colors.grey[600],
                               ),
                               maxLines: 2,
@@ -523,11 +537,22 @@ class _ProductsScreenState extends State<ProductsScreen>
                 ),
                 child: Row(
                   children: [
-                    Icon(
-                      _getCategoryIcon(product.category),
-                      color: _getCategoryColor(product.category),
-                      size: 28,
-                    ),
+                    if (product.imagePath != null)
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.file(
+                          File(product.imagePath!),
+                          width: 48,
+                          height: 48,
+                          fit: BoxFit.cover,
+                        ),
+                      )
+                    else
+                      Icon(
+                        _getCategoryIcon(product.category),
+                        color: _getCategoryColor(product.category),
+                        size: 28,
+                      ),
                     const SizedBox(width: 12),
                     Expanded(
                       child: Column(

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -36,6 +36,31 @@ class FileService {
     return newPath;
   }
 
+  /// Pick an image for a product and store it under `product_images`.
+  /// Returns the saved file path or `null` if no image was selected.
+  Future<String?> pickAndSaveProductImage({
+    XFile? image,
+    Directory? baseDirectory,
+  }) async {
+    final picker = ImagePicker();
+    final XFile? selectedImage =
+        image ?? await picker.pickImage(source: ImageSource.gallery, maxWidth: 512, maxHeight: 512, imageQuality: 85);
+
+    if (selectedImage == null) return null;
+
+    final directory = baseDirectory ?? await getApplicationDocumentsDirectory();
+    final imgDir = Directory('${directory.path}/product_images');
+    if (!await imgDir.exists()) {
+      await imgDir.create(recursive: true);
+    }
+    final extension = selectedImage.path.split('.').last;
+    final fileName =
+        'product_${DateTime.now().millisecondsSinceEpoch}.$extension';
+    final newPath = '${imgDir.path}/$fileName';
+    await File(selectedImage.path).copy(newPath);
+    return newPath;
+  }
+
   /// Save exported [data] to a json file in the application documents
   /// directory. Returns the written file path.
   Future<String> saveExportedData(


### PR DESCRIPTION
## Summary
- allow storing optional product image path
- support picking & saving product images
- show and manage product images in the form dialog
- adapt product list for small screens and display product photos
- include images in product detail view

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846566b3654832c88b5d005acc51f61