### PR TITLE
Adjust dashboard stats card UI

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -424,9 +424,9 @@ class _HomeScreenState extends State<HomeScreen>
       ) {
     final iconSize = responsiveValue(
       context,
-      mobile: 20.0,
-      tablet: 24.0,
-      desktop: 28.0,
+      mobile: 24.0,
+      tablet: 28.0,
+      desktop: 32.0,
     );
 
     Widget cardContent = Card(
@@ -475,29 +475,25 @@ class _HomeScreenState extends State<HomeScreen>
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Flexible(
-                      child: FittedBox(
-                        fit: BoxFit.scaleDown,
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          value,
-                          style: headlineSmall(context).copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
+                      child: Text(
+                        value,
+                        style: headlineSmall(context).copyWith(
+                          fontWeight: FontWeight.bold,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                     SizedBox(height: spacingXS(context)),
                     Flexible(
-                      child: FittedBox(
-                        fit: BoxFit.scaleDown,
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          title,
-                          style: labelMedium(context).copyWith(
-                            color: Colors.grey[600],
-                            fontWeight: FontWeight.w500,
-                          ),
+                      child: Text(
+                        title,
+                        style: labelMedium(context).copyWith(
+                          color: Colors.grey[600],
+                          fontWeight: FontWeight.w500,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- tweak stats card icon sizes for all breakpoints
- remove FittedBox wrappers in stats card text

## Testing
- `./setup.sh` *(fails: CONNECT tunnel failed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847667dd7a0832c834d11b403d99d29