### PR TITLE
Implement min/max clamping for responsive font sizes

### DIFF
--- a/lib/mixins/responsive_text_mixin.dart
+++ b/lib/mixins/responsive_text_mixin.dart
@@ -15,53 +15,82 @@ mixin ResponsiveTextMixin on ResponsiveBreakpointsMixin {
   }
 
   // Responsive font size
-  double responsiveFontSize(BuildContext context, double baseSize, {bool respectTextScale = true}) {
+  double responsiveFontSize(
+    BuildContext context,
+    double baseSize, {
+    bool respectTextScale = true,
+    double? min,
+    double? max,
+  }) {
     final scale = _baseFontScale(context);
-    final textScale = respectTextScale ? MediaQuery.of(context).textScaleFactor : 1.0;
-    return baseSize * scale * textScale;
+    final textScale =
+        respectTextScale ? MediaQuery.of(context).textScaleFactor : 1.0;
+    double size = baseSize * scale * textScale;
+    if (min != null || max != null) {
+      size = size.clamp(min ?? size, max ?? size);
+    }
+    return size;
   }
 
   // Text style helpers
-  TextStyle responsiveTextStyle(BuildContext context, TextStyle baseStyle, {bool respectTextScale = true}) {
+  TextStyle responsiveTextStyle(
+    BuildContext context,
+    TextStyle baseStyle, {
+    bool respectTextScale = true,
+    double? min,
+    double? max,
+  }) {
     final fontSize = baseStyle.fontSize;
     if (fontSize == null) return baseStyle;
 
     return baseStyle.copyWith(
-      fontSize: responsiveFontSize(context, fontSize, respectTextScale: respectTextScale),
+      fontSize: responsiveFontSize(
+        context,
+        fontSize,
+        respectTextScale: respectTextScale,
+        min: min,
+        max: max,
+      ),
       height: baseStyle.height, // Preserve line height ratio
     );
   }
 
   // Common text styles
   TextStyle headlineLarge(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-  );
+        context,
+        const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+        min: 14,
+      );
 
   TextStyle headlineMedium(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
-  );
+        context,
+        const TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+        min: 14,
+      );
 
   TextStyle headlineSmall(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-  );
+        context,
+        const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        min: 14,
+      );
 
   TextStyle titleLarge(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
-  );
+        context,
+        const TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+        min: 14,
+      );
 
   TextStyle titleMedium(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-  );
+        context,
+        const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+        min: 14,
+      );
 
   TextStyle titleSmall(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-  );
+        context,
+        const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        min: 14,
+      );
 
   TextStyle bodyLarge(BuildContext context) => responsiveTextStyle(
     context,

--- a/test/responsive_mixins_test.dart
+++ b/test/responsive_mixins_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rufko/mixins/responsive_breakpoints_mixin.dart';
+import 'package:rufko/mixins/responsive_text_mixin.dart';
+
+class _MixinTester with ResponsiveBreakpointsMixin, ResponsiveTextMixin {}
+
+void main() {
+  final testerMixin = _MixinTester();
+
+  testWidgets('responsiveFontSize clamps to min value', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final context = tester.element(find.byType(SizedBox));
+    final size = testerMixin.responsiveFontSize(context, 10, min: 12);
+    expect(size, 12);
+  });
+
+  testWidgets('responsiveFontSize clamps to max value', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final context = tester.element(find.byType(SizedBox));
+    final size = testerMixin.responsiveFontSize(context, 20, max: 18);
+    expect(size, 18);
+  });
+}


### PR DESCRIPTION
## Summary
- allow `responsiveFontSize` to clamp the computed size with optional `min` and `max` values
- plumb new parameters through `responsiveTextStyle`
- ensure heading styles never go below 14px
- add unit tests verifying font size clamping

## Testing
- `bash setup.sh` *(fails: `curl: (56) CONNECT tunnel failed, response 403`)*
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847674a7bfc832c81a27edc997863e0