### PR TITLE
Fix factory constructor in AppSettings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,8 @@ import 'models/quote.dart'; // Contains QuoteItem
 import 'models/roof_scope_data.dart';
 import 'models/project_media.dart';
 import 'models/app_settings.dart';
+import 'models/kanban_board.dart';
+import 'models/kanban_stage.dart';
 import 'models/simplified_quote.dart';
 import 'models/pdf_template.dart'; // Crucial: Import this to get PdfFormFieldTypeAdapter etc.
 import 'models/custom_app_data.dart';
@@ -28,10 +30,12 @@ import 'theme/rufko_theme.dart';
 // Your Screens
 import 'screens/home_screen.dart';
 import 'models/template_category.dart';
+import 'services/notification_service.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Hive.initFlutter();
+  await NotificationService.init();
 
   Hive.registerAdapter(CustomerAdapter());
   Hive.registerAdapter(ProductAdapter());
@@ -41,6 +45,8 @@ void main() async {
   Hive.registerAdapter(RoofScopeDataAdapter());
   Hive.registerAdapter(ProjectMediaAdapter());
   Hive.registerAdapter(AppSettingsAdapter());
+  Hive.registerAdapter(KanbanBoardAdapter());
+  Hive.registerAdapter(KanbanStageAdapter());
   Hive.registerAdapter(QuoteDiscountAdapter());
   Hive.registerAdapter(QuoteLevelAdapter());
   Hive.registerAdapter(SimplifiedMultiLevelQuoteAdapter());

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -1,6 +1,9 @@
 // lib/models/app_settings.dart - ENHANCED VERSION
 
+import 'kanban_board.dart';
+import 'kanban_stage.dart';
 import 'package:hive/hive.dart';
+import 'package:flutter/material.dart';
 
 part 'app_settings.g.dart';
 
@@ -52,6 +55,35 @@ class AppSettings extends HiveObject {
   @HiveField(14)
   double defaultDiscountLimit; // Maximum discount percentage allowed
 
+  // Kanban settings
+  @HiveField(15)
+  bool useKanbanCustomerView;
+
+  @HiveField(16)
+  List<KanbanStage> kanbanStages;
+
+  // Multiple Kanban boards
+  @HiveField(17)
+  List<KanbanBoard> kanbanBoards;
+
+  // Urgency colouring thresholds in days
+  @HiveField(18)
+  int yellowThresholdDays;
+
+  @HiveField(19)
+  int orangeThresholdDays;
+
+  @HiveField(20)
+  int redThresholdDays;
+
+  // Categories required to complete a customer's documentation
+  @HiveField(21)
+  List<String> requiredMediaCategories;
+
+  // Track last successful automatic backup
+  @HiveField(22)
+  DateTime? lastBackupDate;
+
   AppSettings({
     String? id,
     List<String>? productCategories,
@@ -67,12 +99,61 @@ class AppSettings extends HiveObject {
     List<String>? discountTypes,
     this.allowProductDiscountToggle = true,
     this.defaultDiscountLimit = 25.0,
+    this.useKanbanCustomerView = false,
+    List<KanbanStage>? kanbanStages,
+    List<KanbanBoard>? kanbanBoards,
     DateTime? updatedAt,
+    this.yellowThresholdDays = 3,
+    this.orangeThresholdDays = 7,
+    this.redThresholdDays = 14,
+    List<String>? requiredMediaCategories,
+    this.lastBackupDate,
   })  : productCategories = productCategories ?? ['Materials', 'Roofing', 'Gutters', 'Labor', 'Other'],
         productUnits = productUnits ?? ['sq ft', 'lin ft', 'each', 'hour', 'day', 'bundle', 'roll', 'sheet'],
         defaultUnit = defaultUnit ?? 'sq ft',
         defaultQuoteLevelNames = defaultQuoteLevelNames ?? ['Basic', 'Standard', 'Premium'],
         discountTypes = discountTypes ?? ['percentage', 'fixed_amount', 'voucher'],
+        kanbanStages = kanbanStages ?? [
+          KanbanStage(id: 'lead', name: 'lead', color: Colors.blue.value),
+          KanbanStage(id: 'contacted', name: 'contacted', color: Colors.indigo.value),
+          KanbanStage(id: 'quoted', name: 'quoted', color: Colors.purple.value),
+          KanbanStage(id: 'negotiation', name: 'negotiation', color: Colors.orange.value),
+          KanbanStage(id: 'closed', name: 'closed', color: Colors.green.value),
+          KanbanStage(id: 'lost', name: 'lost', color: Colors.red.value),
+        ],
+        kanbanBoards = kanbanBoards ?? [
+          KanbanBoard(
+            id: 'sales-pipeline',
+            name: 'Sales Pipeline',
+            stages: kanbanStages ?? const [],
+          ),
+          KanbanBoard(
+            id: 'warranty-service',
+            name: 'Warranty/Service',
+            stages: [
+              KanbanStage(id: 'requested', name: 'requested', color: Colors.blueAccent.value),
+              KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+              KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.orange.value),
+              KanbanStage(id: 'done', name: 'done', color: Colors.green.value),
+            ],
+          ),
+          KanbanBoard(
+            id: 'post-sale-projects',
+            name: 'Post-Sale Projects',
+            stages: [
+              KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+              KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.blue.value),
+              KanbanStage(id: 'getting-materials', name: 'getting materials', color: Colors.orange.value),
+              KanbanStage(id: 'work-done', name: 'work done', color: Colors.green.value),
+            ],
+          ),
+        ],
+        requiredMediaCategories = requiredMediaCategories ?? [
+          'roofscope_reports',
+          'contracts',
+          'permits',
+          'insurance_docs',
+        ],
         updatedAt = updatedAt ?? DateTime.now() {
     this.id = id ?? 'singleton_app_settings';
   }
@@ -184,6 +265,57 @@ class AppSettings extends HiveObject {
     if (isInBox) save();
   }
 
+  // Update urgency colour thresholds
+  void updateUrgencyThresholds({int? yellowDays, int? orangeDays, int? redDays}) {
+    if (yellowDays != null) yellowThresholdDays = yellowDays;
+    if (orangeDays != null) orangeThresholdDays = orangeDays;
+    if (redDays != null) redThresholdDays = redDays;
+    updatedAt = DateTime.now();
+    if (isInBox) save();
+  }
+
+  // Update backup timestamp
+  void updateLastBackupDate(DateTime date) {
+    lastBackupDate = date;
+    updatedAt = DateTime.now();
+    if (isInBox) save();
+  }
+
+  // Kanban board management
+  void addKanbanBoard(KanbanBoard board) {
+    kanbanBoards.add(board);
+    updatedAt = DateTime.now();
+    if (isInBox) save();
+  }
+
+  void renameKanbanBoard(String id, String newName) {
+    final board = kanbanBoards.firstWhere(
+      (b) => b.id == id,
+      orElse: () => KanbanBoard(name: '', stages: const []),
+    );
+    if (board.name.isNotEmpty) {
+      board.name = newName;
+      updatedAt = DateTime.now();
+      if (isInBox) save();
+    }
+  }
+
+  void deleteKanbanBoard(String id) {
+    kanbanBoards.removeWhere((b) => b.id == id);
+    updatedAt = DateTime.now();
+    if (isInBox) save();
+  }
+
+  void cloneKanbanBoard(String id) {
+    final board = kanbanBoards.firstWhere(
+      (b) => b.id == id,
+      orElse: () => KanbanBoard(name: '', stages: const []),
+    );
+    if (board.name.isNotEmpty) {
+      addKanbanBoard(board.clone());
+    }
+  }
+
   Map<String, dynamic> toMap() {
     return {
       'id': id,
@@ -200,17 +332,71 @@ class AppSettings extends HiveObject {
       'discountTypes': discountTypes,
       'allowProductDiscountToggle': allowProductDiscountToggle,
       'defaultDiscountLimit': defaultDiscountLimit,
+      'useKanbanCustomerView': useKanbanCustomerView,
+      'kanbanStages': kanbanStages.map((s) => s.toMap()).toList(),
+      'kanbanBoards': kanbanBoards.map((b) => b.toMap()).toList(),
+      'yellowThresholdDays': yellowThresholdDays,
+      'orangeThresholdDays': orangeThresholdDays,
+      'redThresholdDays': redThresholdDays,
+      'requiredMediaCategories': requiredMediaCategories,
+      'lastBackupDate': lastBackupDate?.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
     };
   }
 
   factory AppSettings.fromMap(Map<String, dynamic> map) {
+    final parsedStages = map['kanbanStages'] != null
+        ? (map['kanbanStages'] as List)
+            .map((e) => KanbanStage.fromMap(Map<String, dynamic>.from(e)))
+            .toList()
+        : [
+            KanbanStage(id: 'lead', name: 'lead', color: Colors.blue.value),
+            KanbanStage(id: 'contacted', name: 'contacted', color: Colors.indigo.value),
+            KanbanStage(id: 'quoted', name: 'quoted', color: Colors.purple.value),
+            KanbanStage(id: 'negotiation', name: 'negotiation', color: Colors.orange.value),
+            KanbanStage(id: 'closed', name: 'closed', color: Colors.green.value),
+            KanbanStage(id: 'lost', name: 'lost', color: Colors.red.value),
+          ];
+
+    final parsedBoards = map['kanbanBoards'] != null
+        ? (map['kanbanBoards'] as List)
+            .map((e) => KanbanBoard.fromMap(Map<String, dynamic>.from(e)))
+            .toList()
+        : [
+            KanbanBoard(
+              id: 'sales-pipeline',
+              name: 'Sales Pipeline',
+              stages: parsedStages,
+            ),
+            KanbanBoard(
+              id: 'warranty-service',
+              name: 'Warranty/Service',
+              stages: [
+                KanbanStage(id: 'requested', name: 'requested', color: Colors.blueAccent.value),
+                KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+                KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.orange.value),
+                KanbanStage(id: 'done', name: 'done', color: Colors.green.value),
+              ],
+            ),
+            KanbanBoard(
+              id: 'post-sale-projects',
+              name: 'Post-Sale Projects',
+              stages: [
+                KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+                KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.blue.value),
+                KanbanStage(id: 'getting-materials', name: 'getting materials', color: Colors.orange.value),
+                KanbanStage(id: 'work-done', name: 'work done', color: Colors.green.value),
+              ],
+            ),
+          ];
+
     return AppSettings(
       id: map['id'] ?? 'singleton_app_settings',
       productCategories: List<String>.from(map['productCategories'] ?? []),
       productUnits: List<String>.from(map['productUnits'] ?? []),
       defaultUnit: map['defaultUnit'] ?? 'sq ft',
-      defaultQuoteLevelNames: List<String>.from(map['defaultQuoteLevelNames'] ?? ['Basic', 'Standard', 'Premium']),
+      defaultQuoteLevelNames:
+          List<String>.from(map['defaultQuoteLevelNames'] ?? ['Basic', 'Standard', 'Premium']),
       taxRate: map['taxRate']?.toDouble() ?? 0.0,
       companyName: map['companyName'],
       companyAddress: map['companyAddress'],
@@ -220,7 +406,20 @@ class AppSettings extends HiveObject {
       discountTypes: List<String>.from(map['discountTypes'] ?? ['percentage', 'fixed_amount', 'voucher']),
       allowProductDiscountToggle: map['allowProductDiscountToggle'] ?? true,
       defaultDiscountLimit: map['defaultDiscountLimit']?.toDouble() ?? 25.0,
+      useKanbanCustomerView: map['useKanbanCustomerView'] ?? false,
+      kanbanStages: parsedStages,
+      kanbanBoards: parsedBoards,
       updatedAt: map['updatedAt'] != null ? DateTime.parse(map['updatedAt']) : DateTime.now(),
+      yellowThresholdDays: map['yellowThresholdDays'] ?? 3,
+      orangeThresholdDays: map['orangeThresholdDays'] ?? 7,
+      redThresholdDays: map['redThresholdDays'] ?? 14,
+      requiredMediaCategories: List<String>.from(map['requiredMediaCategories'] ?? [
+        'roofscope_reports',
+        'contracts',
+        'permits',
+        'insurance_docs',
+      ]),
+      lastBackupDate: map['lastBackupDate'] != null ? DateTime.parse(map['lastBackupDate']) : null,
     );
   }
 

--- a/lib/models/app_settings.g.dart
+++ b/lib/models/app_settings.g.dart
@@ -31,6 +31,16 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       discountTypes: (fields[12] as List?)?.cast<String>(),
       allowProductDiscountToggle: fields[13] as bool,
       defaultDiscountLimit: fields[14] as double,
+      useKanbanCustomerView: fields[15] as bool,
+      kanbanStages: (fields[16] as List).cast<KanbanStage>(),
+      kanbanBoards: (fields[17] as List?)?.cast<KanbanBoard>(),
+      yellowThresholdDays: fields[18] as int? ?? 3,
+      orangeThresholdDays: fields[19] as int? ?? 7,
+      redThresholdDays: fields[20] as int? ?? 14,
+      requiredMediaCategories:
+          (fields[21] as List?)?.cast<String>() ??
+              ['roofscope_reports', 'contracts', 'permits', 'insurance_docs'],
+      lastBackupDate: fields[22] as DateTime?,
       updatedAt: fields[4] as DateTime?,
     );
   }
@@ -38,7 +48,7 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
   @override
   void write(BinaryWriter writer, AppSettings obj) {
     writer
-      ..writeByte(15)
+      ..writeByte(23)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -68,7 +78,23 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       ..writeByte(13)
       ..write(obj.allowProductDiscountToggle)
       ..writeByte(14)
-      ..write(obj.defaultDiscountLimit);
+      ..write(obj.defaultDiscountLimit)
+      ..writeByte(15)
+      ..write(obj.useKanbanCustomerView)
+      ..writeByte(16)
+      ..write(obj.kanbanStages)
+      ..writeByte(17)
+      ..write(obj.kanbanBoards)
+      ..writeByte(18)
+      ..write(obj.yellowThresholdDays)
+      ..writeByte(19)
+      ..write(obj.orangeThresholdDays)
+      ..writeByte(20)
+      ..write(obj.redThresholdDays)
+      ..writeByte(21)
+      ..write(obj.requiredMediaCategories)
+      ..writeByte(22)
+      ..write(obj.lastBackupDate);
   }
 
   @override

--- a/lib/models/customer.dart
+++ b/lib/models/customer.dart
@@ -49,6 +49,23 @@ class Customer extends HiveObject {
 
   @HiveField(13) // Next available field number
   Map<String, dynamic> inspectionData;
+
+  // Kanban stage/status field (stores stage id)
+  @HiveField(14)
+  String stage;
+
+  @HiveField(15)
+  String boardId;
+
+  // Track last reminder notification to avoid duplicates
+  @HiveField(16)
+  DateTime? lastReminderDate;
+
+  @HiveField(17)
+  double? latitude;
+
+  @HiveField(18)
+  double? longitude;
   // --- END NEW STRUCTURED ADDRESS FIELDS ---
 
   Customer({
@@ -67,6 +84,11 @@ class Customer extends HiveObject {
     this.stateAbbreviation,
     this.zipCode,
     Map<String, dynamic>? inspectionData,
+    this.stage = 'lead',
+    this.boardId = 'sales-pipeline',
+    this.lastReminderDate,
+    this.latitude,
+    this.longitude,
   })  : communicationHistory = communicationHistory ?? [],
         inspectionData = inspectionData ?? {},
         createdAt = createdAt ?? DateTime.now(),
@@ -269,6 +291,11 @@ class Customer extends HiveObject {
       'stateAbbreviation': stateAbbreviation,
       'zipCode': zipCode,
       'inspectionData': inspectionData,
+      'stage': stage,
+      'boardId': boardId,
+      'lastReminderDate': lastReminderDate?.toIso8601String(),
+      'latitude': latitude,
+      'longitude': longitude,
     };
 
   }
@@ -288,6 +315,13 @@ class Customer extends HiveObject {
       stateAbbreviation: map['stateAbbreviation'],
       zipCode: map['zipCode'],
       inspectionData: Map<String, dynamic>.from(map['inspectionData'] ?? {}),
+      stage: map['stage'] ?? 'lead',
+      boardId: map['boardId'] ?? 'sales-pipeline',
+      lastReminderDate: map['lastReminderDate'] != null
+          ? DateTime.parse(map['lastReminderDate'])
+          : null,
+      latitude: (map['latitude'] as num?)?.toDouble(),
+      longitude: (map['longitude'] as num?)?.toDouble(),
     );
   }
 

--- a/lib/models/customer.g.dart
+++ b/lib/models/customer.g.dart
@@ -30,13 +30,18 @@ class CustomerAdapter extends TypeAdapter<Customer> {
       stateAbbreviation: fields[11] as String?,
       zipCode: fields[12] as String?,
       inspectionData: (fields[13] as Map?)?.cast<String, dynamic>(),
+      stage: fields[14] as String? ?? 'lead',
+      boardId: fields[15] as String? ?? 'sales-pipeline',
+      lastReminderDate: fields[16] as DateTime?,
+      latitude: (fields[17] as num?)?.toDouble(),
+      longitude: (fields[18] as num?)?.toDouble(),
     );
   }
 
   @override
   void write(BinaryWriter writer, Customer obj) {
     writer
-      ..writeByte(13)
+      ..writeByte(18)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -62,7 +67,17 @@ class CustomerAdapter extends TypeAdapter<Customer> {
       ..writeByte(12)
       ..write(obj.zipCode)
       ..writeByte(13)
-      ..write(obj.inspectionData);
+      ..write(obj.inspectionData)
+      ..writeByte(14)
+      ..write(obj.stage)
+      ..writeByte(15)
+      ..write(obj.boardId)
+      ..writeByte(16)
+      ..write(obj.lastReminderDate)
+      ..writeByte(17)
+      ..write(obj.latitude)
+      ..writeByte(18)
+      ..write(obj.longitude);
   }
 
   @override

--- a/lib/models/kanban_board.dart
+++ b/lib/models/kanban_board.dart
@@ -1,0 +1,51 @@
+import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
+import 'kanban_stage.dart';
+
+part 'kanban_board.g.dart';
+
+@HiveType(typeId: 28)
+class KanbanBoard extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String name;
+
+  @HiveField(2)
+  List<KanbanStage> stages;
+
+  KanbanBoard({
+    String? id,
+    required this.name,
+    List<KanbanStage>? stages,
+  })  : id = id ?? const Uuid().v4(),
+        stages = stages ?? const [];
+
+  KanbanBoard clone({String? newName}) {
+    return KanbanBoard(
+      name: newName ?? '${name} Copy',
+      stages: stages.map((s) => s.clone()).toList(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'stages': stages.map((s) => s.toMap()).toList(),
+    };
+  }
+
+  factory KanbanBoard.fromMap(Map<String, dynamic> map) {
+    return KanbanBoard(
+      id: map['id'],
+      name: map['name'] ?? 'Board',
+      stages: map['stages'] != null
+          ? (map['stages'] as List)
+              .map((e) => KanbanStage.fromMap(Map<String, dynamic>.from(e)))
+              .toList()
+          : const [],
+    );
+  }
+}

--- a/lib/models/kanban_board.g.dart
+++ b/lib/models/kanban_board.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'kanban_board.dart';
+
+class KanbanBoardAdapter extends TypeAdapter<KanbanBoard> {
+  @override
+  final int typeId = 28;
+
+  @override
+  KanbanBoard read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return KanbanBoard(
+      id: fields[0] as String?,
+      name: fields[1] as String,
+      stages: (fields[2] as List).cast<KanbanStage>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, KanbanBoard obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.stages);
+  }
+}

--- a/lib/models/kanban_stage.dart
+++ b/lib/models/kanban_stage.dart
@@ -1,0 +1,47 @@
+import 'package:hive/hive.dart';
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+part 'kanban_stage.g.dart';
+
+@HiveType(typeId: 29)
+class KanbanStage extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String name;
+
+  @HiveField(2)
+  int color;
+
+  KanbanStage({
+    String? id,
+    required this.name,
+    int? color,
+  })  : id = id ?? const Uuid().v4(),
+        color = color ?? Colors.blue.value;
+
+  KanbanStage clone({String? newName}) {
+    return KanbanStage(
+      name: newName ?? name,
+      color: color,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'color': color,
+    };
+  }
+
+  factory KanbanStage.fromMap(Map<String, dynamic> map) {
+    return KanbanStage(
+      id: map['id'],
+      name: map['name'] ?? '',
+      color: map['color'] ?? Colors.blue.value,
+    );
+  }
+}

--- a/lib/models/kanban_stage.g.dart
+++ b/lib/models/kanban_stage.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'kanban_stage.dart';
+
+class KanbanStageAdapter extends TypeAdapter<KanbanStage> {
+  @override
+  final int typeId = 29;
+
+  @override
+  KanbanStage read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return KanbanStage(
+      id: fields[0] as String?,
+      name: fields[1] as String,
+      color: fields[2] as int?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, KanbanStage obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.color);
+  }
+}

--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -16,6 +16,8 @@ import '../services/pdf_service.dart';
 import '../services/template_service.dart';
 import '../services/file_service.dart';
 import '../services/tax_service.dart';
+import '../services/notification_service.dart';
+import '../services/backup_service.dart';
 import '../models/message_template.dart';
 import '../models/email_template.dart';
 import '../models/template_category.dart';
@@ -69,6 +71,8 @@ class AppStateProvider extends ChangeNotifier {
     setLoading(true, 'Initializing app data...');
     await _loadAppSettings();
     await loadAllData();
+    await _scheduleUrgencyReminders();
+    await _performDailyBackup();
     await _ensureInspectionCategoryExists();
     setLoading(false);
   }
@@ -349,6 +353,7 @@ class AppStateProvider extends ChangeNotifier {
   Future<void> addCustomer(Customer customer) async {
     await _db.saveCustomer(customer);
     _customers.add(customer);
+    await _scheduleReminderForCustomer(customer);
     notifyListeners();
   }
 
@@ -356,6 +361,7 @@ class AppStateProvider extends ChangeNotifier {
     await _db.saveCustomer(customer);
     final index = _customers.indexWhere((c) => c.id == customer.id);
     if (index != -1) _customers[index] = customer;
+    await _scheduleReminderForCustomer(customer);
     notifyListeners();
   }
 
@@ -377,6 +383,70 @@ class AppStateProvider extends ChangeNotifier {
     await _db.deleteCustomer(customerId);
     _customers.removeWhere((c) => c.id == customerId);
     notifyListeners();
+  }
+
+  Future<void> _scheduleUrgencyReminders() async {
+    if (_appSettings == null) return;
+    for (final customer in _customers) {
+      await _scheduleReminderForCustomer(customer);
+    }
+  }
+
+  Future<void> _performDailyBackup() async {
+    final settings = _appSettings;
+    if (settings == null) return;
+    final now = DateTime.now();
+    if (settings.lastBackupDate == null || !_isSameDay(settings.lastBackupDate!, now)) {
+      try {
+        final data = await _db.exportAllData();
+        final path = await BackupService.instance.saveEncryptedBackup(data);
+        settings.updateLastBackupDate(now);
+        await _db.saveAppSettings(settings);
+        if (kDebugMode) debugPrint('Daily backup saved to $path');
+      } catch (e) {
+        if (kDebugMode) debugPrint('Daily backup failed: $e');
+      }
+    }
+  }
+
+
+  Future<void> _scheduleReminderForCustomer(Customer customer) async {
+    final settings = _appSettings;
+    if (settings == null) return;
+    final now = DateTime.now();
+    final daysIdle = now.difference(customer.updatedAt).inDays;
+    final today8am = DateTime(now.year, now.month, now.day, 8);
+    final next8am = now.isBefore(today8am) ? today8am : today8am.add(const Duration(days: 1));
+
+    if (daysIdle >= settings.redThresholdDays) {
+      if (customer.lastReminderDate == null || !_isSameDay(customer.lastReminderDate!, now)) {
+        await NotificationService.scheduleNotification(
+          id: customer.id.hashCode,
+          title: 'Customer overdue',
+          body: '${customer.name} has been idle for $daysIdle days',
+          scheduledDate: next8am,
+        );
+        customer.lastReminderDate = next8am;
+        await _db.saveCustomer(customer);
+      }
+    } else if (daysIdle == settings.orangeThresholdDays && customer.lastReminderDate == null) {
+      await NotificationService.scheduleNotification(
+        id: customer.id.hashCode,
+        title: 'Follow up today',
+        body: '${customer.name} has been idle for $daysIdle days',
+        scheduledDate: next8am,
+      );
+      customer.lastReminderDate = next8am;
+      await _db.saveCustomer(customer);
+    } else if (daysIdle < settings.orangeThresholdDays && customer.lastReminderDate != null) {
+      await NotificationService.cancel(customer.id.hashCode);
+      customer.lastReminderDate = null;
+      await _db.saveCustomer(customer);
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
   }
   Future<void> loadTemplateCategories() async {
     try {

--- a/lib/screens/customer_detail/media_tab.dart
+++ b/lib/screens/customer_detail/media_tab.dart
@@ -7,6 +7,7 @@ import '../../utils/common_utils.dart';
 
 import '../../models/customer.dart';
 import '../../models/project_media.dart';
+import '../../models/app_settings.dart';
 import '../../providers/app_state_provider.dart';
 
 class MediaTab extends StatelessWidget {
@@ -185,6 +186,9 @@ class MediaTab extends StatelessWidget {
                   ),
                 ),
               ),
+              const SizedBox(height: 8),
+              if (appState.appSettings?.requiredMediaCategories.isNotEmpty ?? false)
+                _buildRequiredDocsChecklist(context, mediaItems, appState.appSettings!),
               if (isSelectionMode) ...[
                 const SizedBox(height: 8),
                 Card(
@@ -403,4 +407,46 @@ class MediaTab extends StatelessWidget {
   }
 
   // formatPhotoCategoryName moved to common_utils.dart
+
+  Widget _buildRequiredDocsChecklist(
+      BuildContext context, List<ProjectMedia> mediaItems, AppSettings settings) {
+    final Map<String, bool> status = {
+      for (final cat in settings.requiredMediaCategories)
+        cat: mediaItems.any((m) => m.category == cat),
+    };
+    if (status.isEmpty) return const SizedBox.shrink();
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Required Documents',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            ...status.entries.map(
+              (e) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Row(
+                  children: [
+                    Icon(
+                      e.value ? Icons.check_circle : Icons.radio_button_unchecked,
+                      color: e.value ? Colors.green : Colors.grey,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(formatCategoryName(e.key)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/lib/screens/customers_kanban_screen.dart
+++ b/lib/screens/customers_kanban_screen.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/customer.dart';
+import '../providers/app_state_provider.dart';
+import '../widgets/customer_card.dart';
+import 'customer_detail_screen.dart';
+
+class CustomersKanbanScreen extends StatefulWidget {
+  const CustomersKanbanScreen({super.key});
+
+  @override
+  State<CustomersKanbanScreen> createState() => _CustomersKanbanScreenState();
+}
+
+class _CustomersKanbanScreenState extends State<CustomersKanbanScreen> {
+  String? _selectedBoardId;
+  final Map<String, String> _sortBy = {}; // stageId -> sort mode
+
+  @override
+  void initState() {
+    super.initState();
+    final boards =
+        Provider.of<AppStateProvider>(context, listen: false).appSettings?.kanbanBoards;
+    if (boards != null && boards.isNotEmpty) {
+      _selectedBoardId = boards.first.id;
+      for (final stage in boards.first.stages) {
+        _sortBy[stage.id] = 'priority';
+      }
+    }
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Customers'),
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black87,
+        elevation: 0,
+        actions: [
+          Consumer<AppStateProvider>(
+            builder: (context, appState, child) {
+              final boards = appState.appSettings?.kanbanBoards ?? [];
+              if (boards.isEmpty) return const SizedBox.shrink();
+              return DropdownButton<String>(
+                value: _selectedBoardId ?? boards.first.id,
+                underline: const SizedBox(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedBoardId = value;
+                    });
+                  }
+                },
+                items: boards
+                    .map((b) => DropdownMenuItem(
+                          value: b.id,
+                          child: Text(b.name),
+                        ))
+                    .toList(),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Consumer<AppStateProvider>(
+        builder: (context, appState, child) {
+          final boards = appState.appSettings?.kanbanBoards ?? [];
+          if (boards.isEmpty) return const SizedBox();
+          final board = boards.firstWhere(
+            (b) => b.id == (_selectedBoardId ?? boards.first.id),
+            orElse: () => boards.first,
+          );
+          final stages = board.stages;
+          for (final stage in stages) {
+            _sortBy.putIfAbsent(stage.id, () => 'priority');
+          }
+          final Map<String, List<Customer>> grouped = {
+            for (final stage in stages) stage.id: [],
+          };
+          for (final customer in appState.customers
+              .where((c) => c.boardId == board.id)) {
+            grouped.putIfAbsent(customer.stage, () => []).add(customer);
+          }
+          for (final stage in stages) {
+            final customers = grouped[stage.id];
+            if (customers == null) continue;
+            customers.sort((a, b) => _compareCustomers(
+                a, b, _sortBy[stage.id] ?? 'priority', appState));
+          }
+
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: stages.map((stage) {
+                final customers = grouped[stage.id] ?? [];
+                return DragTarget<Customer>(
+                  onWillAccept: (data) => data != null && data.stage != stage.id,
+                  onAccept: (customer) {
+                    customer
+                      ..stage = stage.id
+                      ..updatedAt = DateTime.now();
+                    appState.updateCustomer(customer);
+                  },
+                  builder: (context, candidate, rejected) {
+                    return Container(
+                      width: 300,
+                      margin: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                            decoration: BoxDecoration(
+                              color: Color(stage.color).withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    stage.name.toUpperCase(),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(color: Color(stage.color)),
+                                  ),
+                                ),
+                                PopupMenuButton<String>(
+                                  onSelected: (value) => setState(() {
+                                    _sortBy[stage.id] = value;
+                                  }),
+                                  itemBuilder: (context) => [
+                                    const PopupMenuItem(value: 'priority', child: Text('Priority')),
+                                    const PopupMenuItem(value: 'next', child: Text('Next Action')),
+                                    const PopupMenuItem(value: 'deal', child: Text('Deal Value')),
+                                    const PopupMenuItem(value: 'days', child: Text('Days Stuck')),
+                                  ],
+                                  icon: const Icon(Icons.sort, size: 18),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Flexible(
+                            child: Container(
+                              padding: const EdgeInsets.all(8),
+                              decoration: BoxDecoration(
+                                color: candidate.isNotEmpty
+                                    ? Colors.blue.withOpacity(0.1)
+                                    : Colors.grey[100],
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: customers.isEmpty
+                                  ? const Center(child: Text('No customers'))
+                                  : ListView.builder(
+                                      itemCount: customers.length,
+                                      itemBuilder: (context, index) {
+                                        final customer = customers[index];
+                                        final stageName = stage.name;
+                                        return LongPressDraggable<Customer>(
+                                          data: customer,
+                                          feedback: Material(
+                                            color: Colors.transparent,
+                                            child: SizedBox(
+                                              width: 280,
+                                              child: CustomerCard(
+                                                customer: customer,
+                                                quoteCount: appState.getSimplifiedQuotesForCustomer(customer.id).length,
+                                                stageLabel: stageName,
+                                                stageColor: Color(stage.color),
+                                                urgencyColor: _getUrgencyColor(appState, customer),
+                                              ),
+                                            ),
+                                          ),
+                                          childWhenDragging: Opacity(
+                                            opacity: 0.5,
+                                            child: CustomerCard(
+                                              customer: customer,
+                                              quoteCount: appState.getSimplifiedQuotesForCustomer(customer.id).length,
+                                              stageLabel: stageName,
+                                              stageColor: Color(stage.color),
+                                              urgencyColor: _getUrgencyColor(appState, customer),
+                                            ),
+                                          ),
+                                          child: CustomerCard(
+                                            customer: customer,
+                                            quoteCount: appState.getSimplifiedQuotesForCustomer(customer.id).length,
+                                            stageLabel: stageName,
+                                            stageColor: Color(stage.color),
+                                            urgencyColor: _getUrgencyColor(appState, customer),
+                                            onTap: () => _showCustomerDetailDrawer(customer),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              }).toList(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Color _getUrgencyColor(AppStateProvider appState, Customer customer) {
+    final settings = appState.appSettings;
+    if (settings == null) return Colors.white;
+    final daysIdle = DateTime.now().difference(customer.updatedAt).inDays;
+    if (daysIdle >= settings.redThresholdDays) return Colors.red.shade100;
+    if (daysIdle >= settings.orangeThresholdDays) return Colors.orange.shade100;
+    if (daysIdle >= settings.yellowThresholdDays) return Colors.yellow.shade100;
+    return Colors.white;
+  }
+
+  int _urgencyLevel(AppStateProvider appState, Customer customer) {
+    final settings = appState.appSettings;
+    if (settings == null) return 0;
+    final daysIdle = DateTime.now().difference(customer.updatedAt).inDays;
+    if (daysIdle >= settings.redThresholdDays) return 3;
+    if (daysIdle >= settings.orangeThresholdDays) return 2;
+    if (daysIdle >= settings.yellowThresholdDays) return 1;
+    return 0;
+  }
+
+  DateTime? _getNextActionDate(Customer customer) {
+    final regex = RegExp(r'FOLLOW-UP \(([0-9-]+)\)');
+    DateTime? next;
+    final now = DateTime.now();
+    for (final entry in customer.communicationHistory) {
+      final match = regex.firstMatch(entry);
+      if (match != null) {
+        final date = DateTime.tryParse(match.group(1)!);
+        if (date != null && date.isAfter(now)) {
+          if (next == null || date.isBefore(next)) next = date;
+        }
+      }
+    }
+    return next;
+  }
+
+  double _getDealValue(AppStateProvider appState, Customer customer) {
+    final quotes = appState.getSimplifiedQuotesForCustomer(customer.id);
+    double maxValue = 0.0;
+    for (final q in quotes) {
+      if (q.levels.isEmpty) continue;
+      final total = q.calculateFinalTotal(
+        selectedLevelId: q.levels.first.id,
+        selectedAddons: q.addons,
+      );
+      if (total > maxValue) maxValue = total;
+    }
+    return maxValue;
+  }
+
+  int _compareCustomers(Customer a, Customer b, String mode, AppStateProvider appState) {
+    switch (mode) {
+      case 'next':
+        final aDate = _getNextActionDate(a) ?? DateTime(9999);
+        final bDate = _getNextActionDate(b) ?? DateTime(9999);
+        return aDate.compareTo(bDate);
+      case 'deal':
+        final aVal = _getDealValue(appState, a);
+        final bVal = _getDealValue(appState, b);
+        return bVal.compareTo(aVal);
+      case 'days':
+        final aDays = DateTime.now().difference(a.updatedAt).inDays;
+        final bDays = DateTime.now().difference(b.updatedAt).inDays;
+        return bDays.compareTo(aDays);
+      default:
+        final aUrg = _urgencyLevel(appState, a);
+        final bUrg = _urgencyLevel(appState, b);
+        if (aUrg != bUrg) return bUrg - aUrg;
+        final aDays2 = DateTime.now().difference(a.updatedAt).inDays;
+        final bDays2 = DateTime.now().difference(b.updatedAt).inDays;
+        return bDays2.compareTo(aDays2);
+    }
+  }
+
+  void _showCustomerDetailDrawer(Customer customer) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => SafeArea(
+        child: FractionallySizedBox(
+          heightFactor: 0.95,
+          child: CustomerDetailScreen(customer: customer),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/customers_map_screen.dart
+++ b/lib/screens/customers_map_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/app_state_provider.dart';
+import '../models/customer.dart';
+import 'customer_detail_screen.dart';
+
+class CustomersMapScreen extends StatelessWidget {
+  const CustomersMapScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = context.watch<AppStateProvider>();
+    final customers = appState.customers;
+
+    List<Marker> markers = customers
+        .where((c) => c.latitude != null && c.longitude != null)
+        .map((customer) {
+      final color = _urgencyColor(appState, customer);
+      return Marker(
+        width: 40,
+        height: 40,
+        point: LatLng(customer.latitude!, customer.longitude!),
+        builder: (ctx) => IconButton(
+          icon: Icon(Icons.location_on, color: color),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => CustomerDetailScreen(customer: customer),
+              ),
+            );
+          },
+        ),
+      );
+    }).toList();
+
+    if (markers.isEmpty) {
+      // Provide sample markers if no coordinates available
+      markers = [
+        Marker(
+          width: 40,
+          height: 40,
+          point: const LatLng(37.7749, -122.4194),
+          builder: (_) => const Icon(Icons.location_on, color: Colors.blue),
+        ),
+        Marker(
+          width: 40,
+          height: 40,
+          point: const LatLng(34.0522, -118.2437),
+          builder: (_) => const Icon(Icons.location_on, color: Colors.green),
+        ),
+      ];
+    }
+
+    final center = markers.isNotEmpty ? markers.first.point : const LatLng(0, 0);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Customers Map')),
+      body: FlutterMap(
+        options: MapOptions(center: center, zoom: 4),
+        children: [
+          TileLayer(
+            urlTemplate:
+                'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}',
+            additionalOptions: const {
+              'id': 'mapbox/streets-v11',
+              'accessToken': 'YOUR_MAPBOX_ACCESS_TOKEN',
+            },
+          ),
+          MarkerLayer(markers: markers),
+        ],
+      ),
+    );
+  }
+
+  Color _urgencyColor(AppStateProvider appState, Customer customer) {
+    final settings = appState.appSettings;
+    if (settings == null) return Colors.blue;
+    final daysIdle = DateTime.now().difference(customer.updatedAt).inDays;
+    if (daysIdle >= settings.redThresholdDays) return Colors.red;
+    if (daysIdle >= settings.orangeThresholdDays) return Colors.orange;
+    if (daysIdle >= settings.yellowThresholdDays) return Colors.yellow;
+    return Colors.green;
+  }
+}

--- a/lib/screens/customers_screen.dart
+++ b/lib/screens/customers_screen.dart
@@ -6,9 +6,11 @@ import '../providers/app_state_provider.dart';
 import '../models/customer.dart';
 import '../widgets/customer_card.dart';   // Assuming this will be adapted
 import 'customer_detail_screen.dart';
+import 'customers_map_screen.dart';
 import '../mixins/search_mixin.dart';
 import '../mixins/sort_menu_mixin.dart';
 import '../mixins/empty_state_mixin.dart';
+import '../models/kanban_board.dart';
 
 class CustomersScreen extends StatefulWidget {
   const CustomersScreen({super.key});
@@ -52,6 +54,13 @@ class _CustomersScreenState extends State<CustomersScreen>
           IconButton(
             icon: Icon(searchVisible ? Icons.search_off : Icons.search),
             onPressed: toggleSearch,
+          ),
+          IconButton(
+            icon: const Icon(Icons.map),
+            onPressed: () {
+              Navigator.push(context,
+                  MaterialPageRoute(builder: (_) => const CustomersMapScreen()));
+            },
           ),
           PopupMenuButton<String>(
             icon: const Icon(Icons.sort),
@@ -188,9 +197,21 @@ class _CustomersScreenState extends State<CustomersScreen>
         itemBuilder: (context, index) {
           final customer = customers[index];
           final quoteCount = appState.getSimplifiedQuotesForCustomer(customer.id).length;
+          final board = appState.appSettings?.kanbanBoards.firstWhere(
+                (b) => b.id == customer.boardId,
+                orElse: () => appState.appSettings?.kanbanBoards.first ?? KanbanBoard(name: 'Default'),
+              );
+          final stage = board?.stages.firstWhere(
+                (s) => s.id == customer.stage,
+                orElse: () => board!.stages.first,
+              );
+          final color = _getUrgencyColor(appState, customer);
           return CustomerCard(
             customer: customer,
             quoteCount: quoteCount,
+            stageLabel: stage?.name ?? '',
+            stageColor: Color(stage?.color ?? Colors.grey.value),
+            urgencyColor: color,
             onTap: () => _navigateToCustomerDetail(customer),
             onEdit: () => _showEditCustomerDialog(context, customer),
             onDelete: () => _showDeleteConfirmation(context, customer),
@@ -263,6 +284,16 @@ class _CustomersScreenState extends State<CustomersScreen>
       return _sortAscending ? comparison : -comparison;
     });
     return customers;
+  }
+
+  Color _getUrgencyColor(AppStateProvider appState, Customer customer) {
+    final settings = appState.appSettings;
+    if (settings == null) return Colors.white;
+    final daysIdle = DateTime.now().difference(customer.updatedAt).inDays;
+    if (daysIdle >= settings.redThresholdDays) return Colors.red.shade100;
+    if (daysIdle >= settings.orangeThresholdDays) return Colors.orange.shade100;
+    if (daysIdle >= settings.yellowThresholdDays) return Colors.yellow.shade100;
+    return Colors.white;
   }
 
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -15,6 +15,7 @@ import '../mixins/responsive_text_mixin.dart';
 import '../mixins/responsive_widget_mixin.dart';
 
 import 'customers_screen.dart';
+import 'customers_kanban_screen.dart';
 import 'quotes_screen.dart';
 import 'products_screen.dart';
 import 'settings_screen.dart';
@@ -87,9 +88,10 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
+    final useKanban = context.watch<AppStateProvider>().appSettings?.useKanbanCustomerView ?? false;
     final pages = [
       _buildModernDashboard(),
-      const CustomersScreen(),
+      useKanban ? const CustomersKanbanScreen() : const CustomersScreen(),
       const QuotesScreen(),
       const ProductsScreen(),
       const TemplatesScreen(),

--- a/lib/screens/settings/urgency_settings_dialog.dart
+++ b/lib/screens/settings/urgency_settings_dialog.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class UrgencySettingsDialog extends StatefulWidget {
+  final int yellowDays;
+  final int orangeDays;
+  final int redDays;
+  final Function(int, int, int) onSave;
+
+  const UrgencySettingsDialog({
+    super.key,
+    required this.yellowDays,
+    required this.orangeDays,
+    required this.redDays,
+    required this.onSave,
+  });
+
+  @override
+  State<UrgencySettingsDialog> createState() => _UrgencySettingsDialogState();
+}
+
+class _UrgencySettingsDialogState extends State<UrgencySettingsDialog> {
+  late TextEditingController _yellowController;
+  late TextEditingController _orangeController;
+  late TextEditingController _redController;
+
+  @override
+  void initState() {
+    super.initState();
+    _yellowController = TextEditingController(text: widget.yellowDays.toString());
+    _orangeController = TextEditingController(text: widget.orangeDays.toString());
+    _redController = TextEditingController(text: widget.redDays.toString());
+  }
+
+  @override
+  void dispose() {
+    _yellowController.dispose();
+    _orangeController.dispose();
+    _redController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      title: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.red.shade100,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(Icons.warning_amber, color: Colors.red.shade600),
+          ),
+          const SizedBox(width: 12),
+          const Text('Urgency Thresholds'),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildField(_yellowController, 'Yellow after (days)', Colors.yellow.shade600),
+          const SizedBox(height: 12),
+          _buildField(_orangeController, 'Orange after (days)', Colors.orange.shade600),
+          const SizedBox(height: 12),
+          _buildField(_redController, 'Red after (days)', Colors.red.shade600),
+        ],
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+        ElevatedButton(
+          onPressed: () {
+            final yellow = int.tryParse(_yellowController.text) ?? widget.yellowDays;
+            final orange = int.tryParse(_orangeController.text) ?? widget.orangeDays;
+            final red = int.tryParse(_redController.text) ?? widget.redDays;
+            widget.onSave(yellow, orange, red);
+            Navigator.pop(context);
+          },
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildField(TextEditingController controller, String label, Color color) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        prefixIcon: Icon(Icons.timer, color: color),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+        filled: true,
+        fillColor: Colors.white,
+      ),
+      keyboardType: TextInputType.number,
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,10 +7,13 @@ import 'package:open_filex/open_filex.dart';
 import '../providers/app_state_provider.dart';
 import '../models/app_settings.dart';
 
+import '../models/kanban_board.dart';
+import '../models/kanban_stage.dart';
 import 'settings/category_manager_dialog.dart';
 import 'settings/units_manager_dialog.dart';
 import 'settings/quote_levels_manager_dialog.dart';
 import 'settings/discount_settings_dialog.dart';
+import 'settings/urgency_settings_dialog.dart';
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
@@ -47,6 +50,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           _buildSectionHeader('Product Configuration'),
           _buildProductConfigurationSection(),
+          const SizedBox(height: 24),
+
+          _buildSectionHeader('Customer View'),
+          _buildKanbanSettingsSection(),
           const SizedBox(height: 24),
 
           _buildSectionHeader('Company & Business'),
@@ -673,6 +680,262 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ],
           ),
+        );
+      },
+    );
+  }
+
+  Widget _buildKanbanSettingsSection() {
+    return Consumer<AppStateProvider>(
+      builder: (context, appState, child) {
+        final settings = appState.appSettings ?? AppSettings();
+
+        return Card(
+          elevation: 2,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: Colors.blue.shade100,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child:
+                          Icon(Icons.view_kanban, color: Colors.blue.shade600, size: 24),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Use Kanban View',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          Text(
+                            'Replace customer list with Kanban board',
+                            style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Switch(
+                      value: settings.useKanbanCustomerView,
+                      onChanged: (value) {
+                        settings.useKanbanCustomerView = value;
+                        appState.updateAppSettings(settings);
+                      },
+                  activeColor: Theme.of(context).primaryColor,
+                ),
+              ],
+            ),
+          ),
+          _buildSettingsTile(
+            icon: Icons.warning_amber_outlined,
+            iconColor: Colors.red.shade600,
+            title: 'Urgency Thresholds',
+            subtitle:
+                '${settings.yellowThresholdDays}d / ${settings.orangeThresholdDays}d / ${settings.redThresholdDays}d',
+            onTap: _showUrgencySettingsDialog,
+          ),
+          _buildDivider(),
+          if (settings.kanbanBoards.isNotEmpty) _buildDivider(),
+              ...settings.kanbanBoards.map((board) {
+                return ListTile(
+                  title: Text(board.name),
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (val) {
+                      if (val == 'rename') {
+                        _renameBoard(context, board, appState);
+                      } else if (val == 'stages') {
+                        _editStages(context, board, appState);
+                      } else if (val == 'clone') {
+                        settings.cloneKanbanBoard(board.id);
+                        appState.updateAppSettings(settings);
+                      } else if (val == 'delete') {
+                        settings.deleteKanbanBoard(board.id);
+                        appState.updateAppSettings(settings);
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(value: 'rename', child: Text('Rename')),
+                      const PopupMenuItem(value: 'stages', child: Text('Edit Stages')),
+                      const PopupMenuItem(value: 'clone', child: Text('Clone')),
+                      const PopupMenuItem(value: 'delete', child: Text('Delete')),
+                    ],
+                  ),
+                );
+              }).toList(),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: () => _addBoard(context, appState),
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add Board'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _addBoard(BuildContext context, AppStateProvider appState) {
+    final settings = appState.appSettings ?? AppSettings();
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Board'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Board name'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () {
+              final board = KanbanBoard(
+                name: controller.text,
+                stages: [
+                  KanbanStage(id: 'todo', name: 'todo', color: 0xFF2196F3),
+                ],
+              );
+              settings.addKanbanBoard(board);
+              appState.updateAppSettings(settings);
+              Navigator.pop(context);
+            },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _renameBoard(BuildContext context, KanbanBoard board, AppStateProvider appState) {
+    final settings = appState.appSettings ?? AppSettings();
+    final controller = TextEditingController(text: board.name);
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename Board'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Board name'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () {
+              settings.renameKanbanBoard(board.id, controller.text);
+              appState.updateAppSettings(settings);
+              Navigator.pop(context);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _editStages(BuildContext context, KanbanBoard board, AppStateProvider appState) {
+    final settings = appState.appSettings ?? AppSettings();
+    final stages = board.stages.map((s) => KanbanStage(id: s.id, name: s.name, color: s.color)).toList();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: Text('Edit Stages for ${board.name}'),
+              content: SizedBox(
+                width: double.maxFinite,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: stages.length,
+                  itemBuilder: (context, index) {
+                    final stage = stages[index];
+                    return Row(
+                      children: [
+                        GestureDetector(
+                          onTap: () async {
+                            final colors = [Colors.blue, Colors.indigo, Colors.purple, Colors.orange, Colors.green, Colors.red, Colors.teal];
+                            final color = await showDialog<Color>(
+                              context: context,
+                              builder: (context) => SimpleDialog(
+                                title: const Text('Select Color'),
+                                children: colors
+                                    .map((c) => InkWell(
+                                          onTap: () => Navigator.pop(context, c),
+                                          child: Container(height: 30, color: c, margin: const EdgeInsets.all(4)),
+                                        ))
+                                    .toList(),
+                              ),
+                            );
+                            if (color != null) {
+                              setState(() => stage.color = color.value);
+                            }
+                          },
+                          child: Container(width: 24, height: 24, color: Color(stage.color)),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: TextField(
+                            controller: TextEditingController(text: stage.name),
+                            onChanged: (val) => stage.name = val,
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.arrow_upward, size: 16),
+                          onPressed: index == 0
+                              ? null
+                              : () => setState(() {
+                                    final temp = stages.removeAt(index);
+                                    stages.insert(index - 1, temp);
+                                  }),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.arrow_downward, size: 16),
+                          onPressed: index == stages.length - 1
+                              ? null
+                              : () => setState(() {
+                                    final temp = stages.removeAt(index);
+                                    stages.insert(index + 1, temp);
+                                  }),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+              actions: [
+                TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+                TextButton(
+                  onPressed: () {
+                    board.stages
+                      ..clear()
+                      ..addAll(stages);
+                    appState.updateAppSettings(settings);
+                    Navigator.pop(context);
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
         );
       },
     );
@@ -1460,6 +1723,37 @@ class _SettingsScreenState extends State<SettingsScreen> {
               backgroundColor: Colors.green,
               behavior: SnackBarBehavior.floating,
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showUrgencySettingsDialog() {
+    final appState = context.read<AppStateProvider>();
+    final settings = appState.appSettings ?? AppSettings();
+    showDialog(
+      context: context,
+      builder: (context) => UrgencySettingsDialog(
+        yellowDays: settings.yellowThresholdDays,
+        orangeDays: settings.orangeThresholdDays,
+        redDays: settings.redThresholdDays,
+        onSave: (y, o, r) {
+          settings.updateUrgencyThresholds(
+            yellowDays: y,
+            orangeDays: o,
+            redDays: r,
+          );
+          appState.updateAppSettings(settings);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('Urgency thresholds updated!'),
+              backgroundColor: Colors.green,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
             ),
           );
         },

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:encrypt/encrypt.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+
+class BackupService {
+  BackupService._internal();
+  static final BackupService instance = BackupService._internal();
+
+  final Key _key = Key.fromUtf8('rufko_secure_backup_key_123456');
+  final IV _iv = IV.fromLength(16);
+
+  Future<String> saveEncryptedBackup(Map<String, dynamic> data) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final fileName =
+        'rufko_backup_${DateFormat('yyyy-MM-dd_HH-mm').format(DateTime.now())}.enc';
+    final file = File('${directory.path}/$fileName');
+    final jsonString = const JsonEncoder.withIndent('  ').convert(data);
+    final encrypter = Encrypter(AES(_key));
+    final encrypted = encrypter.encrypt(jsonString, iv: _iv);
+    await file.writeAsBytes(encrypted.bytes);
+    return file.path;
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,8 +1,11 @@
 // lib/services/database_service.dart - UPDATED FOR ENHANCED MODELS & CATEGORY FIX
 
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:flutter/material.dart';
 import 'dart:io';
 import 'dart:convert';
+import '../models/kanban_board.dart';
+import '../models/kanban_stage.dart';
 import '../models/customer.dart';
 import '../models/product.dart';
 import '../models/roof_scope_data.dart';
@@ -612,6 +615,59 @@ class DatabaseService {
         discountTypes: ['percentage', 'fixed_amount', 'voucher'],
         allowProductDiscountToggle: true,
         defaultDiscountLimit: 25.0,
+        useKanbanCustomerView: false,
+        yellowThresholdDays: 3,
+        orangeThresholdDays: 7,
+        redThresholdDays: 14,
+        requiredMediaCategories: [
+          'roofscope_reports',
+          'contracts',
+          'permits',
+          'insurance_docs',
+        ],
+        lastBackupDate: null,
+        kanbanStages: [
+          KanbanStage(id: 'lead', name: 'lead', color: Colors.blue.value),
+          KanbanStage(id: 'contacted', name: 'contacted', color: Colors.indigo.value),
+          KanbanStage(id: 'quoted', name: 'quoted', color: Colors.purple.value),
+          KanbanStage(id: 'negotiation', name: 'negotiation', color: Colors.orange.value),
+          KanbanStage(id: 'closed', name: 'closed', color: Colors.green.value),
+          KanbanStage(id: 'lost', name: 'lost', color: Colors.red.value),
+        ],
+        kanbanBoards: [
+          KanbanBoard(
+            id: 'sales-pipeline',
+            name: 'Sales Pipeline',
+            stages: [
+              KanbanStage(id: 'lead', name: 'lead', color: Colors.blue.value),
+              KanbanStage(id: 'contacted', name: 'contacted', color: Colors.indigo.value),
+              KanbanStage(id: 'quoted', name: 'quoted', color: Colors.purple.value),
+              KanbanStage(id: 'negotiation', name: 'negotiation', color: Colors.orange.value),
+              KanbanStage(id: 'closed', name: 'closed', color: Colors.green.value),
+              KanbanStage(id: 'lost', name: 'lost', color: Colors.red.value),
+            ],
+          ),
+          KanbanBoard(
+            id: 'warranty-service',
+            name: 'Warranty/Service',
+            stages: [
+              KanbanStage(id: 'requested', name: 'requested', color: Colors.blueAccent.value),
+              KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+              KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.orange.value),
+              KanbanStage(id: 'done', name: 'done', color: Colors.green.value),
+            ],
+          ),
+          KanbanBoard(
+            id: 'post-sale-projects',
+            name: 'Post-Sale Projects',
+            stages: [
+              KanbanStage(id: 'scheduled', name: 'scheduled', color: Colors.indigo.value),
+              KanbanStage(id: 'in-progress', name: 'in progress', color: Colors.blue.value),
+              KanbanStage(id: 'getting-materials', name: 'getting materials', color: Colors.orange.value),
+              KanbanStage(id: 'work-done', name: 'work done', color: Colors.green.value),
+            ],
+          ),
+        ],
       );
       await saveAppSettings(defaultSettings);
       return defaultSettings;

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
+
+class NotificationService {
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  static Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: android, iOS: ios);
+    await _plugin.initialize(settings);
+    tz.initializeTimeZones();
+  }
+
+  static Future<void> scheduleNotification({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledDate,
+  }) async {
+    final details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'urgency',
+        'Urgency Reminders',
+        importance: Importance.max,
+        priority: Priority.high,
+      ),
+      iOS: const DarwinNotificationDetails(),
+    );
+    await _plugin.zonedSchedule(
+      id,
+      title,
+      body,
+      tz.TZDateTime.from(scheduledDate, tz.local),
+      details,
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+    );
+  }
+
+  static Future<void> cancel(int id) async {
+    await _plugin.cancel(id);
+  }
+}

--- a/lib/widgets/customer_card.dart
+++ b/lib/widgets/customer_card.dart
@@ -10,6 +10,9 @@ class CustomerCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
+  final String? stageLabel;
+  final Color? stageColor;
+  final Color? urgencyColor;
 
   const CustomerCard({
     super.key,
@@ -18,6 +21,9 @@ class CustomerCard extends StatelessWidget {
     this.onTap,
     this.onEdit,
     this.onDelete,
+    this.stageLabel,
+    this.stageColor,
+    this.urgencyColor,
   });
 
   @override
@@ -36,6 +42,7 @@ class CustomerCard extends StatelessWidget {
       elevation: 2,
       margin: const EdgeInsets.only(bottom: 12),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      color: urgencyColor ?? Colors.white,
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(12),
@@ -60,11 +67,30 @@ class CustomerCard extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          customer.name,
-                          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                customer.name,
+                                style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            if (stageLabel != null)
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                                decoration: BoxDecoration(
+                                  color: (stageColor ?? primaryColor).withOpacity(0.1),
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Text(
+                                  stageLabel!,
+                                  style: textTheme.labelSmall?.copyWith(color: stageColor ?? primaryColor),
+                                ),
+                              ),
+                          ],
                         ),
                         if (customer.phone != null || customer.email != null)
                           Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,13 @@ dependencies:
   url_launcher: ^6.2.4        # ← ADD THIS for phone/email/SMS
   permission_handler: ^11.3.0 # ← ADD THIS for permissions
 
+  # Local notifications
+  flutter_local_notifications: ^19.2.1
+  timezone: ^0.10.1
+  encrypt: ^5.0.1
+  flutter_map: ^6.1.0
+  latlong2: ^0.9.0
+
   path: any
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- resolve factory constructor so boards can reference default stages during parsing

## Testing
- `bash setup.sh >/tmp/setup.log && tail -n 20 /tmp/setup.log`
- `flutter format -o none -l 120 $(git ls-files '*.dart')` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684778a7166c832c909516d54c38bf91