### PR TITLE
Extract added products list widget

### DIFF
--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/main_product_selection.dart';
 import '../widgets/permits_section.dart';
 import '../widgets/tax_rate_section.dart';
 import '../widgets/quote_totals_section.dart';
+import '../widgets/added_products_list.dart';
 import '../controllers/quote_form_controller.dart';
 
 class SimplifiedQuoteScreen extends StatefulWidget {
@@ -488,130 +489,11 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
   Widget _buildAddedProductsList() {
     return Column(
       children: [
-        // Added Products Section
-        Card(
-          elevation: 2,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      _quoteType == 'multi-level' ? 'Step 2: Add Products' : 'Step 2: Add Additional Products',
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    ElevatedButton.icon(
-                      onPressed: _showAddProductDialog,
-                      icon: const Icon(Icons.add),
-                      label: const Text('Add Product'),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-
-                if (_addedProducts.isEmpty)
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(32),
-                      child: Column(
-                        children: [
-                          Icon(
-                            Icons.inventory_2_outlined,
-                            size: 48,
-                            color: Colors.grey[400],
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            'No additional products added yet',
-                            style: TextStyle(color: Colors.grey[600]),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            'Click "Add Product" to add materials, labor, etc.',
-                            style: TextStyle(
-                              color: Colors.grey[500],
-                              fontSize: 12,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  )
-                else ...[
-                  Text(
-                    _quoteType == 'multi-level' ? 'Added to ALL quote levels:' : 'Additional products:',
-                    style: TextStyle(
-                      color: Colors.grey[700],
-                      fontWeight: FontWeight.w500,
-                      fontSize: 12,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  ..._addedProducts.map((product) => Card(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    color: Colors.green.shade50,
-                    child: ListTile(
-                      leading: Container(
-                        padding: const EdgeInsets.all(6),
-                        decoration: BoxDecoration(
-                          color: Colors.green.shade100,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        child: Icon(
-                          Icons.check_circle,
-                          color: Colors.green.shade700,
-                          size: 16,
-                        ),
-                      ),
-                      title: Text(
-                        product.productName,
-                        style: const TextStyle(fontWeight: FontWeight.w500),
-                      ),
-                      subtitle: Text(
-                        '${product.quantity.toStringAsFixed(1)} ${product.unit} @ ${NumberFormat.currency(symbol: '\$').format(product.unitPrice)} each',
-                      ),
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Column(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            children: [
-                              Text(
-                                NumberFormat.currency(symbol: '\$').format(product.totalPrice),
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 16,
-                                ),
-                              ),
-                              Text(
-                                'per level',
-                                style: TextStyle(
-                                  fontSize: 10,
-                                  color: Colors.grey[600],
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(width: 8),
-                          IconButton(
-                            icon: const Icon(Icons.delete_outline, color: Colors.red),
-                            onPressed: () => _removeProduct(product),
-                            tooltip: 'Remove from all levels',
-                          ),
-                        ],
-                      ),
-                    ),
-                  )),
-                ],
-              ],
-            ),
-          ),
+        AddedProductsList(
+          addedProducts: _addedProducts,
+          quoteType: _quoteType,
+          onAddProductPressed: _showAddProductDialog,
+          onRemoveProduct: _removeProduct,
         ),
 
         // Quote Totals Section

--- a/lib/widgets/added_products_list.dart
+++ b/lib/widgets/added_products_list.dart
@@ -1,0 +1,158 @@
+// lib/widgets/added_products_list.dart
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/quote.dart';
+
+class AddedProductsList extends StatelessWidget {
+  final List<QuoteItem> addedProducts;
+  final String quoteType;
+  final VoidCallback onAddProductPressed;
+  final Function(QuoteItem) onRemoveProduct;
+
+  const AddedProductsList({
+    super.key,
+    required this.addedProducts,
+    required this.quoteType,
+    required this.onAddProductPressed,
+    required this.onRemoveProduct,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  quoteType == 'multi-level'
+                      ? 'Step 2: Add Products'
+                      : 'Step 2: Add Additional Products',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                ElevatedButton.icon(
+                  onPressed: onAddProductPressed,
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add Product'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (addedProducts.isEmpty)
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Column(
+                    children: [
+                      Icon(
+                        Icons.inventory_2_outlined,
+                        size: 48,
+                        color: Colors.grey[400],
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'No additional products added yet',
+                        style: TextStyle(color: Colors.grey[600]),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Click "Add Product" to add materials, labor, etc.',
+                        style: TextStyle(
+                          color: Colors.grey[500],
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else ...[
+              Text(
+                quoteType == 'multi-level'
+                    ? 'Added to ALL quote levels:'
+                    : 'Additional products:',
+                style: TextStyle(
+                  color: Colors.grey[700],
+                  fontWeight: FontWeight.w500,
+                  fontSize: 12,
+                ),
+              ),
+              const SizedBox(height: 8),
+              ...addedProducts.map(
+                (product) => Card(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  color: Colors.green.shade50,
+                  child: ListTile(
+                    leading: Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: Colors.green.shade100,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Icon(
+                        Icons.check_circle,
+                        color: Colors.green.shade700,
+                        size: 16,
+                      ),
+                    ),
+                    title: Text(
+                      product.productName,
+                      style: const TextStyle(fontWeight: FontWeight.w500),
+                    ),
+                    subtitle: Text(
+                      '${product.quantity.toStringAsFixed(1)} ${product.unit} @ ${NumberFormat.currency(symbol: '\$').format(product.unitPrice)} each',
+                    ),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              NumberFormat.currency(symbol: '\$')
+                                  .format(product.totalPrice),
+                              style: const TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 16,
+                              ),
+                            ),
+                            Text(
+                              'per level',
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: Colors.grey[600],
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(width: 8),
+                        IconButton(
+                          icon: const Icon(
+                            Icons.delete_outline,
+                            color: Colors.red,
+                          ),
+                          onPressed: () => onRemoveProduct(product),
+                          tooltip: 'Remove from all levels',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract added products management UI into `AddedProductsList`
- use new widget in simplified quote screen

## Testing
- `bash setup.sh` *(fails: CONNECT tunnel failed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b4a43a44832cab097b86afde8371