### PR TITLE
Extract inspection floating button widget

### DIFF
--- a/lib/screens/simplified_quote_screen.dart
+++ b/lib/screens/simplified_quote_screen.dart
@@ -10,7 +10,7 @@ import '../models/simplified_quote.dart';
 import '../models/quote.dart';
 import '../providers/app_state_provider.dart';
 import '../models/quote_extras.dart'; // NEW: For PermitItem and CustomLineItem
-import 'package:rufko/screens/inspection_viewer_screen.dart';
+import '../widgets/inspection_floating_button.dart';
 import '../theme/rufko_theme.dart';
 import '../widgets/quote_type_selector.dart';
 import '../widgets/main_product_selection.dart';
@@ -182,152 +182,16 @@ class _SimplifiedQuoteScreenState extends State<SimplifiedQuoteScreen> {
                     ),
                   ),
                 ),
-          floatingActionButton: _buildInspectionFloatingButton(),
+          floatingActionButton: InspectionFloatingButton(
+            customer: widget.customer,
+            appState: context.read<AppStateProvider>(),
+          ),
           floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         );
       },
     );
   }
 
-  Widget _buildInspectionFloatingButton() {
-    // Check if there are any inspection documents for this customer
-    final appState = context.read<AppStateProvider>();
-    final inspectionDocs = appState.getInspectionDocumentsForCustomer(widget.customer.id);
-
-    if (inspectionDocs.isEmpty) {
-      return const SizedBox.shrink(); // Don't show button if no inspection docs
-    }
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: 60), // Offset to avoid overlapping
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          // Badge showing document count
-          Positioned(
-            right: 0,
-            top: 0,
-            child: Container(
-              padding: const EdgeInsets.all(4),
-              decoration: BoxDecoration(
-                color: Colors.red,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              constraints: const BoxConstraints(
-                minWidth: 20,
-                minHeight: 20,
-              ),
-              child: Text(
-                '${inspectionDocs.length}',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-
-          // Main button
-          FloatingActionButton.extended(
-            onPressed: _showInspectionModal,
-            icon: const Icon(Icons.assignment),
-            label: const Text('Inspection'),
-            backgroundColor: Colors.green,
-            foregroundColor: Colors.white,
-            elevation: 4,
-            tooltip: 'View ${inspectionDocs.length} inspection document${inspectionDocs.length == 1 ? '' : 's'}',
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showInspectionModal() {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => DraggableScrollableSheet(
-        initialChildSize: 0.9,
-        minChildSize: 0.5,
-        maxChildSize: 0.95,
-        builder: (context, scrollController) => Container(
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(20),
-              topRight: Radius.circular(20),
-            ),
-          ),
-          child: Column(
-            children: [
-              // Drag handle
-              Container(
-                margin: const EdgeInsets.only(top: 12),
-                width: 40,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: Colors.grey[300],
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-
-              // Header
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(color: Colors.grey[200]!),
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.assignment, color: Colors.green, size: 24),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Inspection Documents',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          Text(
-                            'Reference while building quote',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: Colors.grey[600],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () => Navigator.pop(context),
-                      tooltip: 'Close inspection viewer',
-                    ),
-                  ],
-                ),
-              ),
-
-              // Inspection viewer content - THIS IS THE FIX
-              Expanded(
-                child: InspectionViewerScreen(
-                  customer: widget.customer,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 
   Widget _buildMainProductSelection() {
     return Column(

--- a/lib/widgets/inspection_floating_button.dart
+++ b/lib/widgets/inspection_floating_button.dart
@@ -1,0 +1,149 @@
+// lib/widgets/inspection_floating_button.dart
+
+import 'package:flutter/material.dart';
+import '../models/customer.dart';
+import '../providers/app_state_provider.dart';
+import '../screens/inspection_viewer_screen.dart';
+
+class InspectionFloatingButton extends StatelessWidget {
+  final Customer customer;
+  final AppStateProvider appState;
+
+  const InspectionFloatingButton({
+    super.key,
+    required this.customer,
+    required this.appState,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final inspectionDocs = appState.getInspectionDocumentsForCustomer(customer.id);
+
+    if (inspectionDocs.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 60),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Positioned(
+            right: 0,
+            top: 0,
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                color: Colors.red,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              constraints: const BoxConstraints(
+                minWidth: 20,
+                minHeight: 20,
+              ),
+              child: Text(
+                '${inspectionDocs.length}',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          FloatingActionButton.extended(
+            onPressed: () => _showInspectionModal(context),
+            icon: const Icon(Icons.assignment),
+            label: const Text('Inspection'),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            elevation: 4,
+            tooltip:
+                'View ${inspectionDocs.length} inspection document${inspectionDocs.length == 1 ? '' : 's'}',
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showInspectionModal(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.9,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        builder: (context, scrollController) => Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: Column(
+            children: [
+              Container(
+                margin: const EdgeInsets.only(top: 12),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(color: Colors.grey[200]!),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.assignment, color: Colors.green, size: 24),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Inspection Documents',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            'Reference while building quote',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () => Navigator.pop(context),
+                      tooltip: 'Close inspection viewer',
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: InspectionViewerScreen(
+                  customer: customer,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- move inspection floating button and modal logic to `InspectionFloatingButton`
- use new widget in simplified quote screen

## Testing
- `bash ./setup.sh` *(fails: CONNECT tunnel failed)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5f2ce20832ca3ddc7b949082ba8