### PR TITLE
Fix clamp logic and widget tests

### DIFF
--- a/lib/mixins/responsive_text_mixin.dart
+++ b/lib/mixins/responsive_text_mixin.dart
@@ -28,8 +28,12 @@ mixin ResponsiveTextMixin on ResponsiveBreakpointsMixin {
     final textScale =
         respectTextScale ? MediaQuery.of(context).textScaleFactor : 1.0;
     double size = baseSize * scale * textScale;
-    if (min != null || max != null) {
-      size = size.clamp(min ?? size, max ?? size);
+    if (min != null && max != null) {
+      size = size.clamp(min, max);
+    } else if (min != null) {
+      if (size < min) size = min;
+    } else if (max != null) {
+      if (size > max) size = max;
     }
     return size;
   }
@@ -95,32 +99,32 @@ mixin ResponsiveTextMixin on ResponsiveBreakpointsMixin {
       );
 
   TextStyle bodyLarge(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 16),
-  );
+        context,
+        const TextStyle(fontSize: 16),
+      );
 
   TextStyle bodyMedium(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 14),
-  );
+        context,
+        const TextStyle(fontSize: 14),
+      );
 
   TextStyle bodySmall(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 12),
-  );
+        context,
+        const TextStyle(fontSize: 12),
+      );
 
   TextStyle labelLarge(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
-  );
+        context,
+        const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+      );
 
   TextStyle labelMedium(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
-  );
+        context,
+        const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+      );
 
   TextStyle labelSmall(BuildContext context) => responsiveTextStyle(
-    context,
-    const TextStyle(fontSize: 11, fontWeight: FontWeight.w500),
-  );
+        context,
+        const TextStyle(fontSize: 11, fontWeight: FontWeight.w500),
+      );
 }

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,9 +1,30 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:rufko/main.dart';
+import 'package:rufko/providers/app_state_provider.dart';
+import 'package:rufko/providers/customer_provider.dart';
+import 'package:rufko/providers/product_provider.dart';
+import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/providers/template_provider.dart';
+
+Widget _createTestApp() {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (_) => AppStateProvider()),
+      ChangeNotifierProvider(create: (_) => CustomerProvider()),
+      ChangeNotifierProvider(create: (_) => ProductProvider()),
+      ChangeNotifierProvider(create: (_) => QuoteProvider()),
+      ChangeNotifierProvider(create: (_) => TemplateProvider()),
+    ],
+    child: const RufkoApp(),
+  );
+}
 
 void main() {
-  testWidgets('Home screen shows navigation items', (WidgetTester tester) async {
-    await tester.pumpWidget(const RufkoApp());
+  testWidgets('Home screen shows navigation items',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_createTestApp());
 
     expect(find.text('Dashboard'), findsOneWidget);
     expect(find.text('Customers'), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,14 +5,33 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:provider/provider.dart';
 import 'package:rufko/main.dart';
+import 'package:rufko/providers/app_state_provider.dart';
+import 'package:rufko/providers/customer_provider.dart';
+import 'package:rufko/providers/product_provider.dart';
+import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/providers/template_provider.dart';
+
+Widget _createTestApp() {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (_) => AppStateProvider()),
+      ChangeNotifierProvider(create: (_) => CustomerProvider()),
+      ChangeNotifierProvider(create: (_) => ProductProvider()),
+      ChangeNotifierProvider(create: (_) => QuoteProvider()),
+      ChangeNotifierProvider(create: (_) => TemplateProvider()),
+    ],
+    child: const RufkoApp(),
+  );
+}
 
 void main() {
   testWidgets('App smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const RufkoApp());
+    await tester.pumpWidget(_createTestApp());
 
     // Verify that the dashboard tab is visible
     expect(find.text('Dashboard'), findsOneWidget);


### PR DESCRIPTION
## Summary
- avoid invalid clamp operation in `responsiveFontSize`
- wrap `RufkoApp` in providers for widget tests
- add missing Material imports for tests

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6848d3eedcb0832cbcd878270278f71a