### PR TITLE
Add QuoteStateProvider

### DIFF
--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -16,7 +16,6 @@ import 'helpers/data_loading_helper.dart';
 import 'helpers/template_category_helper.dart';
 import 'helpers/message_template_helper.dart';
 import 'helpers/email_template_helper.dart';
-import 'helpers/customer_helper.dart';
 import '../services/template_service.dart';
 import '../services/file_service.dart';
 import '../services/tax_service.dart';
@@ -26,15 +25,18 @@ import '../models/template_category.dart';
 import '../models/custom_app_data.dart';
 import '../models/inspection_document.dart';
 import 'custom_fields_provider.dart';
+import 'customer_state_provider.dart';
+import 'product_state_provider.dart';
+import 'quote_state_provider.dart';
 
 class AppStateProvider extends ChangeNotifier {
   final DatabaseService _db = DatabaseService.instance;
   final PdfService _pdfService = PdfService();
 
-  List<Customer> _customers = [];
-  List<Product> _products = [];
+  late final CustomerStateProvider customerState;
+  late final ProductStateProvider productState;
+  late final QuoteStateProvider quoteState;
   AppSettings? _appSettings;
-  List<SimplifiedMultiLevelQuote> _simplifiedQuotes = [];
   List<RoofScopeData> _roofScopeDataList = [];
   List<ProjectMedia> _projectMedia = [];
   List<PDFTemplate> _pdfTemplates = [];
@@ -47,10 +49,10 @@ class AppStateProvider extends ChangeNotifier {
   String _loadingMessage = '';
 
   // Getters
-  List<Customer> get customers => _customers;
-  List<Product> get products => _products;
+  List<Customer> get customers => customerState.customers;
+  List<Product> get products => productState.products;
   AppSettings? get appSettings => _appSettings;
-  List<SimplifiedMultiLevelQuote> get simplifiedQuotes => _simplifiedQuotes;
+  List<SimplifiedMultiLevelQuote> get simplifiedQuotes => quoteState.quotes;
   List<RoofScopeData> get roofScopeDataList => _roofScopeDataList;
   List<ProjectMedia> get projectMedia => _projectMedia;
   List<PDFTemplate> get pdfTemplates => _pdfTemplates;
@@ -71,7 +73,12 @@ class AppStateProvider extends ChangeNotifier {
   String get loadingMessage => _loadingMessage;
 
   AppStateProvider() {
-    // Constructor can be used for initial setup
+    customerState = CustomerStateProvider(database: _db)
+      ..addListener(notifyListeners);
+    productState = ProductStateProvider(database: _db)
+      ..addListener(notifyListeners);
+    quoteState = QuoteStateProvider(database: _db)
+      ..addListener(notifyListeners);
   }
 
   Future<void> initializeApp() async {
@@ -153,9 +160,9 @@ class AppStateProvider extends ChangeNotifier {
     setLoading(true, 'Loading data...');
     try {
       await Future.wait([
-        loadCustomers(),
-        loadProducts(),
-        loadSimplifiedQuotes(),
+        customerState.loadCustomers(),
+        productState.loadProducts(),
+        quoteState.loadQuotes(),
         loadRoofScopeData(),
         loadProjectMedia(),
         loadPDFTemplates(),
@@ -174,16 +181,9 @@ class AppStateProvider extends ChangeNotifier {
   }
 
   // Individual load methods
-  Future<void> loadCustomers() async {
-    _customers = await DataLoadingHelper.loadCustomers(_db);
-  }
-
-  Future<void> loadProducts() async {
-    _products = await DataLoadingHelper.loadProducts(_db);
-  }
 
   Future<void> loadSimplifiedQuotes() async {
-    _simplifiedQuotes = await DataLoadingHelper.loadSimplifiedQuotes(_db);
+    await quoteState.loadQuotes();
   }
 
   Future<void> loadRoofScopeData() async {
@@ -208,36 +208,23 @@ class AppStateProvider extends ChangeNotifier {
 
   // --- Customer Operations ---
   Future<void> addCustomer(Customer customer) async {
-    await CustomerHelper.addCustomer(
-      db: _db,
-      customers: _customers,
-      customer: customer,
-    );
-    notifyListeners();
+    await customerState.addCustomer(customer);
   }
 
   Future<void> updateCustomer(Customer customer) async {
-    await CustomerHelper.updateCustomer(
-      db: _db,
-      customers: _customers,
-      customer: customer,
-    );
-    notifyListeners();
+    await customerState.updateCustomer(customer);
   }
 
   Future<void> deleteCustomer(String customerId) async {
-    await CustomerHelper.deleteCustomer(
-      db: _db,
-      customers: _customers,
-      quotes: _simplifiedQuotes,
+    await customerState.deleteCustomer(
+      customerId: customerId,
+      quotes: quoteState.quotes,
       roofScopes: _roofScopeDataList,
       media: _projectMedia,
       deleteQuote: deleteSimplifiedQuote,
       deleteRoofScope: deleteRoofScopeData,
       deleteMedia: deleteProjectMedia,
-      customerId: customerId,
     );
-    notifyListeners();
   }
 
   Future<void> loadTemplateCategories() async {
@@ -246,42 +233,21 @@ class AppStateProvider extends ChangeNotifier {
 
   // --- Product Operations ---
   Future<void> addProduct(Product product) async {
-    await _db.saveProduct(product);
-    _products.add(product);
-    notifyListeners();
+    await productState.addProduct(product);
   }
 
   Future<void> updateProduct(Product product) async {
-    await _db.saveProduct(product);
-    final index = _products.indexWhere((p) => p.id == product.id);
-    if (index != -1) _products[index] = product;
-    notifyListeners();
+    await productState.updateProduct(product);
   }
 
   Future<void> deleteProduct(String productId) async {
-    await _db.deleteProduct(productId);
-    _products.removeWhere((p) => p.id == productId);
-    notifyListeners();
+    await productState.deleteProduct(productId);
   }
 
   Future<void> importProducts(List<Product> productsToImport) async {
     setLoading(true, 'Importing products...');
     try {
-      for (final product in productsToImport) {
-        final existingIndex = _products.indexWhere(
-            (p) => p.name.toLowerCase() == product.name.toLowerCase());
-        if (existingIndex != -1) {
-          await _db.saveProduct(product);
-          _products[existingIndex] = product;
-        } else {
-          await _db.saveProduct(product);
-          _products.add(product);
-        }
-      }
-      notifyListeners();
-    } catch (e) {
-      if (kDebugMode) debugPrint('Error importing products: $e');
-      rethrow;
+      await productState.importProducts(productsToImport);
     } finally {
       setLoading(false);
     }
@@ -289,17 +255,11 @@ class AppStateProvider extends ChangeNotifier {
 
   // --- SimplifiedMultiLevelQuote Operations ---
   Future<void> addSimplifiedQuote(SimplifiedMultiLevelQuote quote) async {
-    await _db.saveSimplifiedMultiLevelQuote(quote);
-    _simplifiedQuotes.add(quote);
-    notifyListeners();
+    await quoteState.addSimplifiedQuote(quote);
   }
 
   Future<void> updateSimplifiedQuote(SimplifiedMultiLevelQuote quote) async {
-    quote.updatedAt = DateTime.now();
-    await _db.saveSimplifiedMultiLevelQuote(quote);
-    final index = _simplifiedQuotes.indexWhere((q) => q.id == quote.id);
-    if (index != -1) _simplifiedQuotes[index] = quote;
-    notifyListeners();
+    await quoteState.updateSimplifiedQuote(quote);
   }
 
   Future<void> deleteSimplifiedQuote(String quoteId) async {
@@ -308,14 +268,12 @@ class AppStateProvider extends ChangeNotifier {
     for (var media in mediaForQuote) {
       await deleteProjectMedia(media.id);
     }
-    await _db.deleteSimplifiedMultiLevelQuote(quoteId);
-    _simplifiedQuotes.removeWhere((q) => q.id == quoteId);
-    notifyListeners();
+    await quoteState.deleteSimplifiedQuote(quoteId);
   }
 
   List<SimplifiedMultiLevelQuote> getSimplifiedQuotesForCustomer(
       String customerId) {
-    return _simplifiedQuotes.where((q) => q.customerId == customerId).toList();
+    return quoteState.getSimplifiedQuotesForCustomer(customerId);
   }
 
   Future<String> generateSimplifiedQuotePdf(
@@ -324,8 +282,7 @@ class AppStateProvider extends ChangeNotifier {
     String? selectedLevelId,
     List<String>? selectedAddonIds,
   }) async {
-    return PdfGenerationHelper.generateSimplifiedQuotePdf(
-      _pdfService,
+    return quoteState.generateSimplifiedQuotePdf(
       quote,
       customer,
       selectedLevelId: selectedLevelId,
@@ -924,30 +881,18 @@ class AppStateProvider extends ChangeNotifier {
   String get taxDatabaseStatus => TaxService.getDatabaseStatus();
   // --- Search Operations ---
   List<Customer> searchCustomers(String query) {
-    if (query.isEmpty) return _customers;
-    final lowerQuery = query.toLowerCase();
-    return _customers
-        .where((c) =>
-            c.name.toLowerCase().contains(lowerQuery) ||
-            (c.phone?.contains(lowerQuery) ?? false))
-        .toList();
+    return customerState.searchCustomers(query);
   }
 
   List<Product> searchProducts(String query) {
-    if (query.isEmpty) return _products;
-    final lowerQuery = query.toLowerCase();
-    return _products
-        .where((p) =>
-            p.name.toLowerCase().contains(lowerQuery) ||
-            (p.category.toLowerCase().contains(lowerQuery)))
-        .toList();
+    return productState.searchProducts(query);
   }
 
   List<SimplifiedMultiLevelQuote> searchSimplifiedQuotes(String query) {
-    if (query.isEmpty) return _simplifiedQuotes;
+    if (query.isEmpty) return quoteState.quotes;
     final lowerQuery = query.toLowerCase();
-    return _simplifiedQuotes.where((q) {
-      final customer = _customers.firstWhere((c) => c.id == q.customerId,
+    return quoteState.quotes.where((q) {
+      final customer = customers.firstWhere((c) => c.id == q.customerId,
           orElse: () => Customer(name: ""));
       return q.quoteNumber.toLowerCase().contains(lowerQuery) ||
           customer.name.toLowerCase().contains(lowerQuery);
@@ -957,7 +902,7 @@ class AppStateProvider extends ChangeNotifier {
   // --- Dashboard Statistics ---
   Map<String, dynamic> getDashboardStats() {
     double totalRevenue = 0;
-    for (var quote in _simplifiedQuotes) {
+    for (var quote in quoteState.quotes) {
       if (quote.status.toLowerCase() == 'accepted' && quote.levels.isNotEmpty) {
         var acceptedLevelSubtotal = quote.levels
             .map((l) => l.subtotal)
@@ -966,17 +911,17 @@ class AppStateProvider extends ChangeNotifier {
       }
     }
     return {
-      'totalCustomers': _customers.length,
-      'totalQuotes': _simplifiedQuotes.length,
-      'totalProducts': _products.length,
+      'totalCustomers': customers.length,
+      'totalQuotes': quoteState.quotes.length,
+      'totalProducts': products.length,
       'totalRevenue': totalRevenue,
-      'draftQuotes': _simplifiedQuotes
+      'draftQuotes': quoteState.quotes
           .where((q) => q.status.toLowerCase() == 'draft')
           .length,
-      'sentQuotes': _simplifiedQuotes
+      'sentQuotes': quoteState.quotes
           .where((q) => q.status.toLowerCase() == 'sent')
           .length,
-      'acceptedQuotes': _simplifiedQuotes
+      'acceptedQuotes': quoteState.quotes
           .where((q) => q.status.toLowerCase() == 'accepted')
           .length,
     };

--- a/lib/providers/customer_state_provider.dart
+++ b/lib/providers/customer_state_provider.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/customer.dart';
+import '../models/simplified_quote.dart';
+import '../models/roof_scope_data.dart';
+import '../models/project_media.dart';
+import '../services/database_service.dart';
+import 'helpers/data_loading_helper.dart';
+import 'helpers/customer_helper.dart';
+
+/// Provider responsible for managing [Customer] data and related
+/// relationships. This was extracted from `AppStateProvider` to keep
+/// customer logic self‑contained.
+class CustomerStateProvider extends ChangeNotifier {
+  final DatabaseService _db;
+  List<Customer> _customers = [];
+
+  CustomerStateProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
+
+  List<Customer> get customers => _customers;
+
+  /// Loads all customers from the database.
+  Future<void> loadCustomers() async {
+    _customers = await DataLoadingHelper.loadCustomers(_db);
+    notifyListeners();
+  }
+
+  /// Adds a new customer and persists it to the database.
+  Future<void> addCustomer(Customer customer) async {
+    await CustomerHelper.addCustomer(
+      db: _db,
+      customers: _customers,
+      customer: customer,
+    );
+    notifyListeners();
+  }
+
+  /// Updates an existing customer in memory and storage.
+  Future<void> updateCustomer(Customer customer) async {
+    await CustomerHelper.updateCustomer(
+      db: _db,
+      customers: _customers,
+      customer: customer,
+    );
+    notifyListeners();
+  }
+
+  /// Deletes a customer and all associated records.
+  Future<void> deleteCustomer({
+    required String customerId,
+    required List<SimplifiedMultiLevelQuote> quotes,
+    required List<RoofScopeData> roofScopes,
+    required List<ProjectMedia> media,
+    required Future<void> Function(String) deleteQuote,
+    required Future<void> Function(String) deleteRoofScope,
+    required Future<void> Function(String) deleteMedia,
+  }) async {
+    await CustomerHelper.deleteCustomer(
+      db: _db,
+      customers: _customers,
+      quotes: quotes,
+      roofScopes: roofScopes,
+      media: media,
+      deleteQuote: deleteQuote,
+      deleteRoofScope: deleteRoofScope,
+      deleteMedia: deleteMedia,
+      customerId: customerId,
+    );
+    notifyListeners();
+  }
+
+  /// Returns customers matching the provided search [query].
+  List<Customer> searchCustomers(String query) {
+    if (query.isEmpty) return _customers;
+    final lower = query.toLowerCase();
+    return _customers
+        .where((c) =>
+            c.name.toLowerCase().contains(lower) ||
+            (c.phone?.contains(lower) ?? false))
+        .toList();
+  }
+
+  /// Returns a new list of customers sorted by name.
+  List<Customer> sortByName({bool ascending = true}) {
+    final sorted = [..._customers];
+    sorted.sort((a, b) =>
+        ascending ? a.name.compareTo(b.name) : b.name.compareTo(a.name));
+    return sorted;
+  }
+
+  /// Filters customers by city, case insensitive.
+  List<Customer> filterByCity(String city) {
+    final lowerCity = city.toLowerCase();
+    return _customers.where((c) => c.city?.toLowerCase() == lowerCity).toList();
+  }
+}

--- a/lib/providers/helpers/product_helper.dart
+++ b/lib/providers/helpers/product_helper.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/product.dart';
+import '../../services/database_service.dart';
+
+/// Helper methods for managing [Product] records.
+class ProductHelper {
+  static Future<void> addProduct({
+    required DatabaseService db,
+    required List<Product> products,
+    required Product product,
+  }) async {
+    await db.saveProduct(product);
+    products.add(product);
+    if (kDebugMode) {
+      debugPrint('➕ Added product: ${product.name}');
+    }
+  }
+
+  static Future<void> updateProduct({
+    required DatabaseService db,
+    required List<Product> products,
+    required Product product,
+  }) async {
+    await db.saveProduct(product);
+    final index = products.indexWhere((p) => p.id == product.id);
+    if (index != -1) {
+      products[index] = product;
+      if (kDebugMode) {
+        debugPrint('✅ Updated product in memory');
+      }
+    } else {
+      products.add(product);
+      if (kDebugMode) {
+        debugPrint('⚠️ Product not found in memory, adding it');
+      }
+    }
+  }
+
+  static Future<void> deleteProduct({
+    required DatabaseService db,
+    required List<Product> products,
+    required String productId,
+  }) async {
+    await db.deleteProduct(productId);
+    products.removeWhere((p) => p.id == productId);
+    if (kDebugMode) {
+      debugPrint('🗑️ Deleted product $productId');
+    }
+  }
+}

--- a/lib/providers/helpers/quote_helper.dart
+++ b/lib/providers/helpers/quote_helper.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/simplified_quote.dart';
+import '../../services/database_service.dart';
+
+/// Helper methods for managing [SimplifiedMultiLevelQuote] records.
+class QuoteHelper {
+  static Future<void> addQuote({
+    required DatabaseService db,
+    required List<SimplifiedMultiLevelQuote> quotes,
+    required SimplifiedMultiLevelQuote quote,
+  }) async {
+    await db.saveSimplifiedMultiLevelQuote(quote);
+    quotes.add(quote);
+    if (kDebugMode) {
+      debugPrint('➕ Added quote: ${quote.quoteNumber}');
+    }
+  }
+
+  static Future<void> updateQuote({
+    required DatabaseService db,
+    required List<SimplifiedMultiLevelQuote> quotes,
+    required SimplifiedMultiLevelQuote quote,
+  }) async {
+    quote.updatedAt = DateTime.now();
+    await db.saveSimplifiedMultiLevelQuote(quote);
+    final index = quotes.indexWhere((q) => q.id == quote.id);
+    if (index != -1) {
+      quotes[index] = quote;
+      if (kDebugMode) debugPrint('✅ Updated quote in memory');
+    } else {
+      quotes.add(quote);
+      if (kDebugMode) debugPrint('⚠️ Quote not found in memory, adding it');
+    }
+  }
+
+  static Future<void> deleteQuote({
+    required DatabaseService db,
+    required List<SimplifiedMultiLevelQuote> quotes,
+    required String quoteId,
+  }) async {
+    await db.deleteSimplifiedMultiLevelQuote(quoteId);
+    quotes.removeWhere((q) => q.id == quoteId);
+    if (kDebugMode) debugPrint('🗑️ Deleted quote $quoteId');
+  }
+
+  static Future<void> updateStatus({
+    required DatabaseService db,
+    required List<SimplifiedMultiLevelQuote> quotes,
+    required String quoteId,
+    required String status,
+  }) async {
+    final index = quotes.indexWhere((q) => q.id == quoteId);
+    if (index != -1) {
+      final quote = quotes[index];
+      quote.status = status;
+      quote.updatedAt = DateTime.now();
+      await db.saveSimplifiedMultiLevelQuote(quote);
+      quotes[index] = quote;
+      if (kDebugMode) debugPrint('🔄 Updated status for $quoteId to $status');
+    }
+  }
+}

--- a/lib/providers/product_state_provider.dart
+++ b/lib/providers/product_state_provider.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/product.dart';
+import '../services/database_service.dart';
+import 'helpers/data_loading_helper.dart';
+import 'helpers/product_helper.dart';
+
+/// Provider responsible for managing [Product] data and business rules.
+/// Extracted from `AppStateProvider` to keep product logic isolated.
+class ProductStateProvider extends ChangeNotifier {
+  final DatabaseService _db;
+  List<Product> _products = [];
+
+  ProductStateProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
+
+  List<Product> get products => _products;
+
+  /// Loads all products from the database.
+  Future<void> loadProducts() async {
+    _products = await DataLoadingHelper.loadProducts(_db);
+    notifyListeners();
+  }
+
+  /// Adds a new product and persists it.
+  Future<void> addProduct(Product product) async {
+    await ProductHelper.addProduct(
+        db: _db, products: _products, product: product);
+    notifyListeners();
+  }
+
+  /// Updates an existing product.
+  Future<void> updateProduct(Product product) async {
+    await ProductHelper.updateProduct(
+        db: _db, products: _products, product: product);
+    notifyListeners();
+  }
+
+  /// Deletes a product by [productId].
+  Future<void> deleteProduct(String productId) async {
+    await ProductHelper.deleteProduct(
+        db: _db, products: _products, productId: productId);
+    notifyListeners();
+  }
+
+  /// Imports a list of products, updating existing ones by name.
+  Future<void> importProducts(List<Product> productsToImport) async {
+    for (final product in productsToImport) {
+      final existingIndex = _products.indexWhere(
+          (p) => p.name.toLowerCase() == product.name.toLowerCase());
+      if (existingIndex != -1) {
+        await ProductHelper.updateProduct(
+            db: _db, products: _products, product: product);
+      } else {
+        await ProductHelper.addProduct(
+            db: _db, products: _products, product: product);
+      }
+    }
+    notifyListeners();
+  }
+
+  /// Finds products matching the search [query].
+  List<Product> searchProducts(String query) {
+    if (query.isEmpty) return _products;
+    final lower = query.toLowerCase();
+    return _products
+        .where((p) =>
+            p.name.toLowerCase().contains(lower) ||
+            p.category.toLowerCase().contains(lower))
+        .toList();
+  }
+
+  /// Returns products belonging to [category].
+  List<Product> filterByCategory(String category) {
+    final lower = category.toLowerCase();
+    return _products.where((p) => p.category.toLowerCase() == lower).toList();
+  }
+
+  /// Simple validation to ensure product integrity.
+  bool validateProduct(Product product) {
+    return product.name.trim().isNotEmpty && product.unitPrice >= 0;
+  }
+
+  /// Calculates the price with a percentage [markup].
+  double priceWithMarkup(Product product, double markup) {
+    return product.unitPrice * (1 + markup / 100);
+  }
+}

--- a/lib/providers/quote_state_provider.dart
+++ b/lib/providers/quote_state_provider.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/simplified_quote.dart';
+import '../models/customer.dart';
+import '../services/database_service.dart';
+import '../services/pdf_service.dart';
+import 'helpers/data_loading_helper.dart';
+import 'helpers/quote_helper.dart';
+
+/// Provider responsible for managing [SimplifiedMultiLevelQuote] data and
+/// related operations. Extracted from `AppStateProvider` to isolate quote
+/// management logic.
+class QuoteStateProvider extends ChangeNotifier {
+  final DatabaseService _db;
+  final PdfService _pdfService = PdfService();
+  List<SimplifiedMultiLevelQuote> _quotes = [];
+
+  QuoteStateProvider({DatabaseService? database})
+      : _db = database ?? DatabaseService.instance;
+
+  List<SimplifiedMultiLevelQuote> get quotes => _quotes;
+
+  /// Loads all quotes from the database.
+  Future<void> loadQuotes() async {
+    _quotes = await DataLoadingHelper.loadSimplifiedQuotes(_db);
+    notifyListeners();
+  }
+
+  /// Adds a new quote and persists it.
+  Future<void> addSimplifiedQuote(SimplifiedMultiLevelQuote quote) async {
+    await QuoteHelper.addQuote(db: _db, quotes: _quotes, quote: quote);
+    notifyListeners();
+  }
+
+  /// Updates an existing quote.
+  Future<void> updateSimplifiedQuote(SimplifiedMultiLevelQuote quote) async {
+    await QuoteHelper.updateQuote(db: _db, quotes: _quotes, quote: quote);
+    notifyListeners();
+  }
+
+  /// Deletes a quote by [quoteId].
+  Future<void> deleteSimplifiedQuote(String quoteId) async {
+    await QuoteHelper.deleteQuote(db: _db, quotes: _quotes, quoteId: quoteId);
+    notifyListeners();
+  }
+
+  /// Updates a quote's [status].
+  Future<void> updateQuoteStatus(String quoteId, String status) async {
+    await QuoteHelper.updateStatus(
+        db: _db, quotes: _quotes, quoteId: quoteId, status: status);
+    notifyListeners();
+  }
+
+  /// Returns quotes belonging to the given [customerId].
+  List<SimplifiedMultiLevelQuote> getSimplifiedQuotesForCustomer(
+      String customerId) {
+    return _quotes.where((q) => q.customerId == customerId).toList();
+  }
+
+  /// Finds quotes matching the search [query].
+  List<SimplifiedMultiLevelQuote> searchSimplifiedQuotes(String query) {
+    if (query.isEmpty) return _quotes;
+    final lower = query.toLowerCase();
+    return _quotes
+        .where((q) => q.quoteNumber.toLowerCase().contains(lower))
+        .toList();
+  }
+
+  /// Generates a PDF for the given [quote] and [customer].
+  Future<String> generateSimplifiedQuotePdf(
+    SimplifiedMultiLevelQuote quote,
+    Customer customer, {
+    String? selectedLevelId,
+    List<String>? selectedAddonIds,
+  }) async {
+    return await _pdfService.generateSimplifiedMultiLevelQuotePdf(
+      quote,
+      customer,
+      selectedLevelId: selectedLevelId,
+      selectedAddonIds: selectedAddonIds,
+    );
+  }
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -4,8 +4,8 @@ import 'package:provider/provider.dart';
 import 'package:rufko/main.dart';
 import 'package:rufko/providers/app_state_provider.dart';
 import 'package:rufko/providers/customer_provider.dart';
-import 'package:rufko/providers/product_provider.dart';
-import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/providers/product_state_provider.dart';
+import 'package:rufko/providers/quote_state_provider.dart';
 import 'package:rufko/providers/template_provider.dart';
 
 Widget _createTestApp() {
@@ -13,8 +13,8 @@ Widget _createTestApp() {
     providers: [
       ChangeNotifierProvider(create: (_) => AppStateProvider()),
       ChangeNotifierProvider(create: (_) => CustomerProvider()),
-      ChangeNotifierProvider(create: (_) => ProductProvider()),
-      ChangeNotifierProvider(create: (_) => QuoteProvider()),
+      ChangeNotifierProvider(create: (_) => ProductStateProvider()),
+      ChangeNotifierProvider(create: (_) => QuoteStateProvider()),
       ChangeNotifierProvider(create: (_) => TemplateProvider()),
     ],
     child: const RufkoApp(),

--- a/test/providers/product_provider_test.dart
+++ b/test/providers/product_provider_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:rufko/providers/product_provider.dart';
+import 'package:rufko/providers/product_state_provider.dart';
 import 'package:rufko/models/product.dart';
 import 'package:rufko/services/database_service.dart';
 
@@ -8,11 +8,11 @@ class MockDatabaseService extends Mock implements DatabaseService {}
 
 void main() {
   late MockDatabaseService db;
-  late ProductProvider provider;
+  late ProductStateProvider provider;
 
   setUp(() {
     db = MockDatabaseService();
-    provider = ProductProvider(database: db);
+    provider = ProductStateProvider(database: db);
   });
 
   test('loadProducts populates list', () async {

--- a/test/providers/quote_provider_test.dart
+++ b/test/providers/quote_provider_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/providers/quote_state_provider.dart';
 import 'package:rufko/models/simplified_quote.dart';
 import 'package:rufko/services/database_service.dart';
 
@@ -8,16 +8,17 @@ class MockDatabaseService extends Mock implements DatabaseService {}
 
 void main() {
   late MockDatabaseService db;
-  late QuoteProvider provider;
+  late QuoteStateProvider provider;
 
   setUp(() {
     db = MockDatabaseService();
-    provider = QuoteProvider(database: db);
+    provider = QuoteStateProvider(database: db);
   });
 
   test('loadQuotes populates list', () async {
     final quote = SimplifiedMultiLevelQuote(customerId: '1');
-    when(() => db.getAllSimplifiedMultiLevelQuotes()).thenAnswer((_) async => [quote]);
+    when(() => db.getAllSimplifiedMultiLevelQuotes())
+        .thenAnswer((_) async => [quote]);
 
     await provider.loadQuotes();
 
@@ -26,9 +27,10 @@ void main() {
 
   test('addQuote adds item to list', () async {
     final quote = SimplifiedMultiLevelQuote(customerId: '1');
-    when(() => db.saveSimplifiedMultiLevelQuote(quote)).thenAnswer((_) async {});
+    when(() => db.saveSimplifiedMultiLevelQuote(quote))
+        .thenAnswer((_) async {});
 
-    await provider.addQuote(quote);
+    await provider.addSimplifiedQuote(quote);
 
     expect(provider.quotes.contains(quote), isTrue);
     verify(() => db.saveSimplifiedMultiLevelQuote(quote)).called(1);
@@ -39,9 +41,10 @@ void main() {
     provider.quotes.add(quote);
 
     final updated = SimplifiedMultiLevelQuote(id: quote.id, customerId: '1');
-    when(() => db.saveSimplifiedMultiLevelQuote(updated)).thenAnswer((_) async {});
+    when(() => db.saveSimplifiedMultiLevelQuote(updated))
+        .thenAnswer((_) async {});
 
-    await provider.updateQuote(updated);
+    await provider.updateSimplifiedQuote(updated);
 
     expect(provider.quotes.first.id, updated.id);
   });
@@ -49,9 +52,10 @@ void main() {
   test('deleteQuote removes item from list', () async {
     final quote = SimplifiedMultiLevelQuote(customerId: '1');
     provider.quotes.add(quote);
-    when(() => db.deleteSimplifiedMultiLevelQuote(quote.id)).thenAnswer((_) async {});
+    when(() => db.deleteSimplifiedMultiLevelQuote(quote.id))
+        .thenAnswer((_) async {});
 
-    await provider.deleteQuote(quote.id);
+    await provider.deleteSimplifiedQuote(quote.id);
 
     expect(provider.quotes, isEmpty);
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,8 +11,8 @@ import 'package:provider/provider.dart';
 import 'package:rufko/main.dart';
 import 'package:rufko/providers/app_state_provider.dart';
 import 'package:rufko/providers/customer_provider.dart';
-import 'package:rufko/providers/product_provider.dart';
-import 'package:rufko/providers/quote_provider.dart';
+import 'package:rufko/providers/product_state_provider.dart';
+import 'package:rufko/providers/quote_state_provider.dart';
 import 'package:rufko/providers/template_provider.dart';
 
 Widget _createTestApp() {
@@ -20,8 +20,8 @@ Widget _createTestApp() {
     providers: [
       ChangeNotifierProvider(create: (_) => AppStateProvider()),
       ChangeNotifierProvider(create: (_) => CustomerProvider()),
-      ChangeNotifierProvider(create: (_) => ProductProvider()),
-      ChangeNotifierProvider(create: (_) => QuoteProvider()),
+      ChangeNotifierProvider(create: (_) => ProductStateProvider()),
+      ChangeNotifierProvider(create: (_) => QuoteStateProvider()),
       ChangeNotifierProvider(create: (_) => TemplateProvider()),
     ],
     child: const RufkoApp(),


### PR DESCRIPTION
## Summary
- implement `QuoteStateProvider` with CRUD, search, PDF, and status helpers
- add reusable `QuoteHelper` for DB persistence
- delegate quote logic from `AppStateProvider` to the new provider
- update tests to use `QuoteStateProvider`

## Testing
- `bash setup.sh` *(fails: destination path '/root/flutter' already exists)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684916ff8860832cae9d7aa5f823452f