### PR TITLE
Refactor QuotesScreen with controller classes

### DIFF
--- a/lib/controllers/quote_filter_controller.dart
+++ b/lib/controllers/quote_filter_controller.dart
@@ -1,0 +1,43 @@
+import '../models/customer.dart';
+import '../models/simplified_quote.dart';
+import '../providers/app_state_provider.dart';
+
+/// Provides filtering helpers for [SimplifiedMultiLevelQuote] records.
+class QuoteFilterController {
+  QuoteFilterController(this.appState);
+
+  final AppStateProvider appState;
+
+  List<SimplifiedMultiLevelQuote> getFilteredQuotes({
+    required String status,
+    required String searchQuery,
+  }) {
+    List<SimplifiedMultiLevelQuote> quotes = appState.simplifiedQuotes;
+
+    if (searchQuery.isNotEmpty) {
+      final lowerQuery = searchQuery.toLowerCase();
+      quotes = quotes.where((quote) {
+        final customer = appState.customers.firstWhere(
+          (c) => c.id == quote.customerId,
+          orElse: () => Customer(name: ''),
+        );
+        return quote.quoteNumber.toLowerCase().contains(lowerQuery) ||
+            customer.name.toLowerCase().contains(lowerQuery);
+      }).toList();
+    }
+
+    if (status != 'All') {
+      if (status == 'Expired') {
+        quotes = quotes.where((q) => q.isExpired).toList();
+      } else {
+        quotes = quotes
+            .where((q) => q.status.toLowerCase() == status.toLowerCase())
+            .toList();
+      }
+    }
+
+    // TODO: implement sorting when requirements are defined
+
+    return quotes;
+  }
+}

--- a/lib/controllers/quote_list_builder.dart
+++ b/lib/controllers/quote_list_builder.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/customer.dart';
+import '../models/simplified_quote.dart';
+import '../providers/app_state_provider.dart';
+
+import 'quote_filter_controller.dart';
+import 'quote_navigation_controller.dart';
+
+/// Builds list views and empty state widgets for quotes.
+class QuoteListBuilder {
+  QuoteListBuilder(this.context, this.navigation);
+
+  final BuildContext context;
+  final QuoteNavigationController navigation;
+
+  Widget buildQuotesList({
+    required AppStateProvider appState,
+    required String statusFilter,
+    required String searchQuery,
+  }) {
+    final filter = QuoteFilterController(appState);
+    final quotes = filter.getFilteredQuotes(
+      status: statusFilter,
+      searchQuery: searchQuery,
+    );
+
+    if (quotes.isEmpty) {
+      return buildEmptyState(statusFilter, searchQuery);
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => appState.loadAllData(),
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: quotes.length,
+        itemBuilder: (context, index) {
+          final quote = quotes[index];
+          final customer = appState.customers.firstWhere(
+            (c) => c.id == quote.customerId,
+            orElse: () => Customer(name: 'Unknown Customer'),
+          );
+          return _buildQuoteCard(quote, customer);
+        },
+      ),
+    );
+  }
+
+  Widget buildEmptyState(String status, String searchQuery) {
+    final title =
+        searchQuery.isEmpty ? 'No quotes for "$status"' : 'No quotes found';
+    final subtitle = searchQuery.isEmpty
+        ? 'Create a new quote to see it here.'
+        : 'Try a different search or filter.';
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.receipt_long_outlined, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+              color: Colors.grey[600],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            subtitle,
+            style: TextStyle(color: Colors.grey[500]),
+            textAlign: TextAlign.center,
+          ),
+          if (status == 'All' && searchQuery.isEmpty) ...[
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: navigation.navigateToCreateQuote,
+              icon: const Icon(Icons.add),
+              label: const Text('Create New Quote'),
+            ),
+          ]
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuoteCard(SimplifiedMultiLevelQuote quote, Customer customer) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        title: Text('Quote #: ${quote.quoteNumber}'),
+        subtitle: Text(
+          'Customer: ${customer.name}\nStatus: ${quote.status} - Levels: ${quote.levels.length}',
+        ),
+        trailing: Text(
+          quote.levels.isNotEmpty
+              ? NumberFormat.currency(symbol: '\$')
+                  .format(quote.getDisplayTotalForLevel(quote.levels.first.id))
+              : '\$0.00',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        onTap: () =>
+            navigation.navigateToSimplifiedQuoteDetail(quote, customer),
+        isThreeLine: true,
+      ),
+    );
+  }
+}

--- a/lib/controllers/quote_navigation_controller.dart
+++ b/lib/controllers/quote_navigation_controller.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/customer.dart';
+import '../models/roof_scope_data.dart';
+import '../models/simplified_quote.dart';
+import '../providers/app_state_provider.dart';
+import '../screens/simplified_quote_detail_screen.dart';
+import '../screens/simplified_quote_screen.dart';
+
+/// Manages navigation related to quote actions and creation.
+class QuoteNavigationController {
+  QuoteNavigationController(this.context);
+
+  final BuildContext context;
+
+  void navigateToSimplifiedQuoteDetail(
+      SimplifiedMultiLevelQuote quote, Customer customer) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) =>
+            SimplifiedQuoteDetailScreen(quote: quote, customer: customer),
+      ),
+    );
+  }
+
+  void navigateToCreateQuote(
+      {Customer? customer, RoofScopeData? roofScopeData}) {
+    final appState = context.read<AppStateProvider>();
+    if (appState.customers.isEmpty && customer == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please add a customer first.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    if (customer == null) {
+      _showCustomerSelection(appState, roofScopeData);
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SimplifiedQuoteScreen(
+            customer: customer,
+            roofScopeData: roofScopeData,
+          ),
+        ),
+      );
+    }
+  }
+
+  void _showCustomerSelection(AppStateProvider appState, RoofScopeData? data) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Select Customer for New Quote'),
+        content: SizedBox(
+          width: double.maxFinite,
+          height: 300,
+          child: ListView.builder(
+            itemCount: appState.customers.length,
+            itemBuilder: (context, index) {
+              final cust = appState.customers[index];
+              return ListTile(
+                title: Text(cust.name),
+                onTap: () {
+                  Navigator.of(dialogContext).pop();
+                  navigateToCreateQuote(customer: cust, roofScopeData: data);
+                },
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/quotes_screen.dart
+++ b/lib/screens/quotes_screen.dart
@@ -2,21 +2,19 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:intl/intl.dart';
-
 import '../providers/app_state_provider.dart';
-import '../models/customer.dart';
 import '../models/simplified_quote.dart'; // Using the new quote model
 import '../models/roof_scope_data.dart'; // For creating new quotes
 
+import '../controllers/quote_filter_controller.dart';
+import '../controllers/quote_navigation_controller.dart';
+import '../controllers/quote_list_builder.dart';
 // Import the new screens
 import 'simplified_quote_screen.dart';
 import 'simplified_quote_detail_screen.dart';
 import '../mixins/search_mixin.dart';
 import '../mixins/sort_menu_mixin.dart';
 import '../mixins/empty_state_mixin.dart';
-
-
 
 class QuotesScreen extends StatefulWidget {
   const QuotesScreen({super.key});
@@ -31,13 +29,24 @@ class _QuotesScreenState extends State<QuotesScreen>
   // SearchMixin provides searchController, searchQuery and searchVisible
   // String _sortBy = 'date'; // 'date', 'amount', 'customer', 'status' // You can re-add sorting later
   // bool _sortAscending = false;
+  late QuoteNavigationController _navigationController;
+  late QuoteListBuilder _listBuilder;
 
-  final List<String> _statusTabs = ['All', 'Draft', 'Sent', 'Accepted', 'Declined', 'Expired'];
+  final List<String> _statusTabs = [
+    'All',
+    'Draft',
+    'Sent',
+    'Accepted',
+    'Declined',
+    'Expired'
+  ];
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: _statusTabs.length, vsync: this);
+    _navigationController = QuoteNavigationController(context);
+    _listBuilder = QuoteListBuilder(context, _navigationController);
   }
 
   @override
@@ -95,13 +104,15 @@ class _QuotesScreenState extends State<QuotesScreen>
           }
           return TabBarView(
             controller: _tabController,
-            children: _statusTabs.map((status) => _buildSimplifiedQuotesList(appState, status)).toList(),
+            children: _statusTabs
+                .map((status) => _buildSimplifiedQuotesList(appState, status))
+                .toList(),
           );
         },
       ),
       floatingActionButton: FloatingActionButton.extended(
         heroTag: 'create_quote',
-        onPressed: _navigateToCreateQuoteScreen,
+        onPressed: _navigationController.navigateToCreateQuote,
         icon: const Icon(Icons.add),
         label: const Text('New Quote'),
       ),
@@ -127,11 +138,13 @@ class _QuotesScreenState extends State<QuotesScreen>
             prefixIcon: Icon(Icons.search, color: Colors.grey[600]),
             suffixIcon: searchController.text.isNotEmpty
                 ? IconButton(
-              icon: Icon(Icons.clear, color: Colors.grey[600]),
-              onPressed: clearSearch,
-            ) : null,
+                    icon: Icon(Icons.clear, color: Colors.grey[600]),
+                    onPressed: clearSearch,
+                  )
+                : null,
             border: InputBorder.none,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           ),
           onChanged: (value) => setState(() => searchQuery = value),
         ),
@@ -142,168 +155,20 @@ class _QuotesScreenState extends State<QuotesScreen>
   // Sorting logic can be re-added and adapted for SimplifiedMultiLevelQuote
   // Widget _buildSortMenuItem(String label, IconData icon, String value) { ... }
 
-  Widget _buildSimplifiedQuotesList(AppStateProvider appState, String statusFilter) {
-    List<SimplifiedMultiLevelQuote> quotes = appState.simplifiedQuotes;
-
-    // Apply search filter
-    if (searchQuery.isNotEmpty) {
-      final lowerQuery = searchQuery.toLowerCase();
-      quotes = quotes.where((quote) {
-        final customer = appState.customers.firstWhere(
-              (c) => c.id == quote.customerId,
-          orElse: () => Customer(name: ''), // Handle case where customer might not be found
-        );
-        return quote.quoteNumber.toLowerCase().contains(lowerQuery) ||
-            customer.name.toLowerCase().contains(lowerQuery);
-      }).toList();
-    }
-
-    // Apply status filter
-    if (statusFilter != 'All') {
-      if (statusFilter == 'Expired') {
-        quotes = quotes.where((q) => q.isExpired).toList();
-      } else {
-        quotes = quotes.where((q) => q.status.toLowerCase() == statusFilter.toLowerCase()).toList();
-      }
-    }
-
-    // Apply sorting (can be re-added later)
-    // quotes.sort((a,b) => ...);
-
-
-    if (quotes.isEmpty) {
-      return _buildEmptyState(statusFilter);
-    }
-
-    return RefreshIndicator(
-      onRefresh: () => appState.loadAllData(),
-      child: ListView.builder(
-        padding: const EdgeInsets.all(16),
-        itemCount: quotes.length,
-        itemBuilder: (context, index) {
-          final quote = quotes[index];
-          final customer = appState.customers.firstWhere(
-                (c) => c.id == quote.customerId,
-            orElse: () => Customer(name: 'Unknown Customer'),
-          );
-          // You'll need a QuoteCard or similar widget adapted for SimplifiedMultiLevelQuote
-          // For now, let's use a simple ListTile as a placeholder
-          return Card(
-            margin: const EdgeInsets.only(bottom: 12),
-            child: ListTile(
-              title: Text('Quote #: ${quote.quoteNumber}'),
-              subtitle: Text('Customer: ${customer.name}\nStatus: ${quote.status} - Levels: ${quote.levels.length}'),
-              trailing: Text(
-                // Display a representative total, e.g., from the first level or an average
-                quote.levels.isNotEmpty ? NumberFormat.currency(symbol: '\$').format(quote.getDisplayTotalForLevel(quote.levels.first.id)) : '\$0.00',
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-              onTap: () => _navigateToSimplifiedQuoteDetail(quote, customer),
-              isThreeLine: true,
-            ),
-          );
-        },
-      ),
-    );
-  }
-
-
-  Widget _buildEmptyState(String status) {
-    // ... (your existing _buildEmptyState or _buildEmptyStateContent can be adapted)
-    // Ensure the buttons in empty state call _navigateToCreateQuoteScreen
-    String title = searchQuery.isEmpty ? 'No quotes for "$status"' : 'No quotes found';
-    String subtitle = searchQuery.isEmpty ? 'Create a new quote to see it here.' : 'Try a different search or filter.';
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          buildEmptyState(
-            icon: Icons.receipt_long_outlined,
-            title: title,
-            subtitle: subtitle,
-          ),
-          if (status == 'All' && searchQuery.isEmpty) ...[
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: _navigateToCreateQuoteScreen,
-              icon: const Icon(Icons.add),
-              label: const Text('Create New Quote'),
-            ),
-          ]
-        ],
-      ),
+  Widget _buildSimplifiedQuotesList(
+      AppStateProvider appState, String statusFilter) {
+    return _listBuilder.buildQuotesList(
+      appState: appState,
+      statusFilter: statusFilter,
+      searchQuery: searchQuery,
     );
   }
 
   // _buildStatusBadge, _getLevelColor can remain if used by an adapted QuoteCard
 
-
-  void _navigateToSimplifiedQuoteDetail(SimplifiedMultiLevelQuote quote, Customer customer) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => SimplifiedQuoteDetailScreen(quote: quote, customer: customer),
-      ),
-    );
-  }
-
-  void _navigateToCreateQuoteScreen({Customer? customer, RoofScopeData? roofScopeData}) {
-    final appState = context.read<AppStateProvider>();
-    if (appState.customers.isEmpty && customer == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please add a customer first.'), backgroundColor: Colors.orange),
-      );
-      // Optionally navigate to customer creation screen
-      return;
-    }
-
-    // If no customer is passed, prompt to select one (or simplify to always require customer context)
-    if (customer == null) {
-      _showCustomerSelectionForNewQuote(appState, roofScopeData);
-    } else {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => SimplifiedQuoteScreen(
-            customer: customer,
-            roofScopeData: roofScopeData, // Pass if available from context
-          ),
-        ),
-      );
-    }
-  }
-
-  void _showCustomerSelectionForNewQuote(AppStateProvider appState, RoofScopeData? initialRoofScopeData) {
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Select Customer for New Quote'),
-        content: SizedBox(
-          width: double.maxFinite,
-          height: 300, // Adjust as needed
-          child: ListView.builder(
-            itemCount: appState.customers.length,
-            itemBuilder: (context, index) {
-              final cust = appState.customers[index];
-              return ListTile(
-                title: Text(cust.name),
-                onTap: () {
-                  Navigator.of(dialogContext).pop(); // Close dialog
-                  _navigateToCreateQuoteScreen(customer: cust, roofScopeData: initialRoofScopeData);
-                },
-              );
-            },
-          ),
-        ),
-        actions: [TextButton(onPressed: () => Navigator.of(dialogContext).pop(), child: const Text('Cancel'))],
-      ),
-    );
-  }
-
-
 // --- Methods related to OLD quote systems that need to be removed or heavily adapted ---
 // _createMultiLevelQuote, _showCreateQuoteDialog (old simple quote), _createNewQuote, etc.
-// These are now replaced by _navigateToCreateQuoteScreen which goes to SimplifiedQuoteScreen.
+// These are now replaced by QuoteNavigationController which goes to SimplifiedQuoteScreen.
 // The _showNoRoofScopeDialog and _MultiLevelQuoteDialog are also for the old system.
 // All logic for differentiating between "standard" and "multi-level" quotes at creation
 // is now handled within SimplifiedQuoteScreen by how many levels are configured.
@@ -318,5 +183,4 @@ class _QuotesScreenState extends State<QuotesScreen>
   void _duplicateQuote(Quote quote, AppStateProvider appState) { ... }
   void _generatePdf(Quote quote, Customer customer, AppStateProvider appState) { ... }
   */
-
 }


### PR DESCRIPTION
## Summary
- extract quote filtering logic into `QuoteFilterController`
- add `QuoteNavigationController` for quote-related navigation
- create `QuoteListBuilder` to build quote lists and empty states
- simplify `QuotesScreen` to delegate to new controllers

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6849e82a6584832cb5360b7c23e552e6