### PR TITLE
Implement adaptive widgets and fix layout

### DIFF
--- a/lib/screens/simplified_quote_detail_screen.dart
+++ b/lib/screens/simplified_quote_detail_screen.dart
@@ -1,6 +1,5 @@
 // lib/screens/simplified_quote_detail_screen.dart - ENHANCED WITH DISCOUNTS
 
-
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -17,6 +16,15 @@ import '../widgets/level_details_card.dart';
 import '../widgets/level_selector_card.dart';
 import '../widgets/quote_header_card.dart';
 import '../widgets/quote_total_card.dart';
+import '../widgets/adaptive_quote_card.dart';
+import '../widgets/responsive_level_grid.dart';
+import '../widgets/adaptive_action_button.dart';
+import '../mixins/responsive_breakpoints_mixin.dart';
+import '../mixins/responsive_dimensions_mixin.dart';
+import '../mixins/responsive_spacing_mixin.dart';
+import '../mixins/responsive_text_mixin.dart';
+import '../mixins/responsive_widget_mixin.dart';
+import '../mixins/responsive_layout_mixin.dart';
 
 import 'simplified_quote_screen.dart';
 
@@ -31,10 +39,19 @@ class SimplifiedQuoteDetailScreen extends StatefulWidget {
   });
 
   @override
-  State<SimplifiedQuoteDetailScreen> createState() => _SimplifiedQuoteDetailScreenState();
+  State<SimplifiedQuoteDetailScreen> createState() =>
+      _SimplifiedQuoteDetailScreenState();
 }
 
-class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScreen> {
+class _SimplifiedQuoteDetailScreenState
+    extends State<SimplifiedQuoteDetailScreen>
+    with
+        ResponsiveBreakpointsMixin,
+        ResponsiveDimensionsMixin,
+        ResponsiveSpacingMixin,
+        ResponsiveTextMixin,
+        ResponsiveWidgetMixin,
+        ResponsiveLayoutMixin {
   late final QuoteDetailController _controller;
   late PDFGenerationController _pdfController;
   final _currencyFormat = NumberFormat.currency(symbol: '\$');
@@ -58,16 +75,29 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
     });
   }
 
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[50],
-      body: NestedScrollView(
+    return Theme(
+      data: Theme.of(context).copyWith(
+        visualDensity: responsiveValue(
+          context,
+          mobile: VisualDensity.compact,
+          tablet: VisualDensity.standard,
+          desktop: VisualDensity.comfortable,
+        ),
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.grey[50],
+        body: NestedScrollView(
         headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
           return <Widget>[
             SliverAppBar(
-              expandedHeight: 100,
+              expandedHeight: responsiveValue(
+                context,
+                mobile: 100,
+                tablet: 120,
+                desktop: 140,
+              ),
               floating: false,
               pinned: true,
               backgroundColor: RufkoTheme.primaryColor,
@@ -103,8 +133,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
                 ),
                 PopupMenuButton<String>(
                   icon: const Icon(Icons.more_vert, color: Colors.white),
-                  onSelected: (action) =>
-                      _controller.handleMenuAction(context, action, _pdfController),
+                  onSelected: (action) => _controller.handleMenuAction(
+                      context, action, _pdfController),
                   itemBuilder: (context) => [
                     const PopupMenuItem(
                       value: 'generate_pdf',
@@ -132,7 +162,8 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
                         children: [
                           Icon(Icons.delete, size: 18, color: Colors.red),
                           SizedBox(width: 8),
-                          Text('Delete Quote', style: TextStyle(color: Colors.red)),
+                          Text('Delete Quote',
+                              style: TextStyle(color: Colors.red)),
                         ],
                       ),
                     ),
@@ -142,30 +173,17 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
             ),
           ];
         },
-        body: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildQuoteHeader(),
-              const SizedBox(height: 24),
-              _buildLevelSelector(),
-              const SizedBox(height: 24),
-              if (_controller.selectedLevelId != null) _buildSelectedLevelDetails(),
-              const SizedBox(height: 24),
-              _buildAddonsSection(),
-              const SizedBox(height: 24),
-              _buildDiscountsSection(),
-              const SizedBox(height: 24),
-              _buildTotalSection(),
-              const SizedBox(height: 32),
-              _buildActionButtons(),
-            ],
-          ),
+        body: windowClassBuilder(
+          context: context,
+          compact: _buildMobileLayout(),
+          medium: _buildTabletLayout(),
+          expanded: _buildDesktopLayout(),
         ),
       ),
-    );
+    ),
+  );
   }
+
 
   Widget _buildQuoteHeader() {
     return QuoteHeaderCard(
@@ -175,6 +193,15 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
   }
 
   Widget _buildLevelSelector() {
+    return responsiveBuilder(
+      context: context,
+      mobile: _buildMobileLevelSelector(),
+      tablet: _buildGridLevelSelector(columns: 2),
+      desktop: _buildGridLevelSelector(columns: 3),
+    );
+  }
+
+  Widget _buildMobileLevelSelector() {
     return LevelSelectorCard(
       levels: widget.quote.levels,
       selectedLevelId: _controller.selectedLevelId,
@@ -184,8 +211,56 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
     );
   }
 
+  Widget _buildGridLevelSelector({required int columns}) {
+    return AdaptiveQuoteCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Select Quote Level:',
+            style: titleMedium(context).copyWith(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: spacingLG(context)),
+          ResponsiveLevelGrid(
+            columns: columns,
+            children: widget.quote.levels.map((level) {
+              final isSelected = _controller.selectedLevelId == level.id;
+              final total = widget.quote.getDisplayTotalForLevel(level.id);
+              return ChoiceChip(
+                label: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(level.name,
+                        style: const TextStyle(fontWeight: FontWeight.w600)),
+                    Text(
+                      _currencyFormat.format(total),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isSelected ? Colors.white : null,
+                      ),
+                    ),
+                  ],
+                ),
+                selected: isSelected,
+                onSelected: (selected) {
+                  if (selected) {
+                    _controller.selectLevel(level.id);
+                  }
+                },
+                selectedColor: Theme.of(context).primaryColor,
+                labelStyle:
+                    TextStyle(color: isSelected ? Colors.white : null),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildSelectedLevelDetails() {
-    final level = widget.quote.levels.firstWhere((l) => l.id == _controller.selectedLevelId!);
+    final level = widget.quote.levels
+        .firstWhere((l) => l.id == _controller.selectedLevelId!);
     return LevelDetailsCard(
       level: level,
       quote: widget.quote,
@@ -198,31 +273,45 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       return const SizedBox.shrink();
     }
 
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Optional Add-ons:', style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
-            const SizedBox(height: 12),
-            ...widget.quote.addons.map((addon) => ListTile(
+    return AdaptiveQuoteCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Optional Add-ons:',
+            style: titleMedium(context).copyWith(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: spacingLG(context)),
+          ...widget.quote.addons.map(
+            (addon) => ListTile(
               dense: true,
               title: Text(addon.productName),
-              subtitle: Text('${addon.quantity.toStringAsFixed(1)} ${addon.unit} @ ${_currencyFormat.format(addon.unitPrice)} each'),
-              trailing: Text(_currencyFormat.format(addon.totalPrice), style: const TextStyle(fontWeight: FontWeight.bold)),
-            )),
-            const Divider(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text('Add-ons Total:', style: TextStyle(fontWeight: FontWeight.bold)),
-                Text(_currencyFormat.format(widget.quote.addons.fold(0.0, (sum, addon) => sum + addon.totalPrice)),
-                    style: const TextStyle(fontWeight: FontWeight.bold)),
-              ],
+              subtitle: Text(
+                '${addon.quantity.toStringAsFixed(1)} ${addon.unit} @ ${_currencyFormat.format(addon.unitPrice)} each',
+              ),
+              trailing: Text(
+                _currencyFormat.format(addon.totalPrice),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
             ),
-          ],
-        ),
+          ),
+          const Divider(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Add-ons Total:',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              Text(
+                _currencyFormat.format(
+                  widget.quote.addons.fold(0.0, (sum, addon) => sum + addon.totalPrice),
+                ),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -248,28 +337,174 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
       currencyFormat: _currencyFormat,
     );
   }
+
   Widget _buildActionButtons() {
+    return windowClassBuilder(
+      context: context,
+      compact: _buildStackedButtons(),
+      medium: _buildRowButtons(),
+      expanded: _buildFixedSidebarButtons(),
+    );
+  }
+
+  Widget _buildStackedButtons() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        AdaptiveActionButton(
+          onPressed: _pdfController.generatePdf,
+          icon: const Icon(Icons.picture_as_pdf),
+          label: 'Generate PDF',
+        ),
+        SizedBox(height: spacingMD(context)),
+        AdaptiveActionButton(
+          onPressed: () => _controller.updateQuoteStatus(context),
+          icon: const Icon(Icons.send),
+          label: _controller.getStatusButtonText(),
+          backgroundColor: RufkoTheme.primaryColor,
+          foregroundColor: Colors.white,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRowButtons() {
     return Row(
       children: [
         Expanded(
-          child: OutlinedButton.icon(
+          child: AdaptiveActionButton(
             onPressed: _pdfController.generatePdf,
             icon: const Icon(Icons.picture_as_pdf),
-            label: const Text('Generate PDF'),
+            label: 'Generate PDF',
           ),
         ),
-        const SizedBox(width: 12),
+        SizedBox(width: spacingLG(context)),
         Expanded(
-          child: ElevatedButton.icon(
+          child: AdaptiveActionButton(
             onPressed: () => _controller.updateQuoteStatus(context),
             icon: const Icon(Icons.send),
-            label: Text(_controller.getStatusButtonText()),
+            label: _controller.getStatusButtonText(),
+            backgroundColor: RufkoTheme.primaryColor,
+            foregroundColor: Colors.white,
           ),
         ),
       ],
     );
   }
 
+  Widget _buildFixedSidebarButtons() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        AdaptiveActionButton(
+          onPressed: _pdfController.generatePdf,
+          icon: const Icon(Icons.picture_as_pdf),
+          label: 'Generate PDF',
+        ),
+        SizedBox(height: spacingLG(context)),
+        AdaptiveActionButton(
+          onPressed: () => _controller.updateQuoteStatus(context),
+          icon: const Icon(Icons.send),
+          label: _controller.getStatusButtonText(),
+          backgroundColor: RufkoTheme.primaryColor,
+          foregroundColor: Colors.white,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMainContent() {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxWidth: isExpanded(context) ? 1200 : double.infinity,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildQuoteHeader(),
+          SizedBox(height: spacingXL(context)),
+          _buildLevelSelector(),
+          SizedBox(height: spacingXL(context)),
+          if (_controller.selectedLevelId != null) _buildSelectedLevelDetails(),
+          SizedBox(height: spacingXL(context)),
+          _buildAddonsSection(),
+          SizedBox(height: spacingXL(context)),
+          _buildDiscountsSection(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSidebar() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildTotalSection(),
+        SizedBox(height: spacingXL(context)),
+        _buildActionButtons(),
+      ],
+    );
+  }
+
+  Widget _buildMobileLayout() {
+    return SingleChildScrollView(
+      padding: screenPadding(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildMainContent(),
+          SizedBox(height: spacingXXL(context)),
+          _buildSidebar(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabletLayout() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: 3,
+          child: SingleChildScrollView(
+            padding: screenPadding(context),
+            child: _buildMainContent(),
+          ),
+        ),
+        SizedBox(width: spacingLG(context)),
+        Expanded(
+          flex: 2,
+          child: SingleChildScrollView(
+            padding: screenPadding(context),
+            child: _buildSidebar(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDesktopLayout() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: 2,
+          child: SingleChildScrollView(
+            padding: screenPadding(context),
+            child: _buildMainContent(),
+          ),
+        ),
+        SizedBox(width: spacingLG(context)),
+        SizedBox(
+          width: 350,
+          child: SingleChildScrollView(
+            padding: screenPadding(context),
+            child: _buildSidebar(),
+          ),
+        ),
+      ],
+    );
+  }
 
   void _addDiscount() {
     showDialog(
@@ -293,9 +528,11 @@ class _SimplifiedQuoteDetailScreenState extends State<SimplifiedQuoteDetailScree
           customer: widget.customer,
           existingQuote: widget.quote, // Pass the quote to edit
           roofScopeData: widget.quote.roofScopeDataId != null
-              ? context.read<AppStateProvider>().roofScopeDataList
-              .where((rs) => rs.id == widget.quote.roofScopeDataId)
-              .firstOrNull
+              ? context
+                  .read<AppStateProvider>()
+                  .roofScopeDataList
+                  .where((rs) => rs.id == widget.quote.roofScopeDataId)
+                  .firstOrNull
               : null,
         ),
       ),
@@ -316,7 +553,14 @@ class _DiscountDialog extends StatefulWidget {
   State<_DiscountDialog> createState() => _DiscountDialogState();
 }
 
-class _DiscountDialogState extends State<_DiscountDialog> {
+class _DiscountDialogState extends State<_DiscountDialog>
+    with
+        ResponsiveBreakpointsMixin,
+        ResponsiveDimensionsMixin,
+        ResponsiveSpacingMixin,
+        ResponsiveTextMixin,
+        ResponsiveWidgetMixin,
+        ResponsiveLayoutMixin {
   final _formKey = GlobalKey<FormState>();
   final _valueController = TextEditingController();
   final _codeController = TextEditingController();
@@ -326,20 +570,24 @@ class _DiscountDialogState extends State<_DiscountDialog> {
   bool _applyToAddons = true;
   DateTime? _expiryDate;
 
-
   @override
   Widget build(BuildContext context) {
     return Dialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Container(
-        width: MediaQuery.of(context).size.width * 0.9,
+        width: responsiveValue(
+          context,
+          mobile: screenWidth(context) * 0.9,
+          tablet: 500,
+          desktop: 600,
+        ),
         constraints: const BoxConstraints(maxHeight: 600),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             // Clean Header - matching your blue theme
             Container(
-              padding: const EdgeInsets.all(20),
+              padding: cardPadding(context),
               decoration: const BoxDecoration(
                 color: RufkoTheme.primaryColor,
                 borderRadius: BorderRadius.only(
@@ -350,15 +598,11 @@ class _DiscountDialogState extends State<_DiscountDialog> {
               child: Row(
                 children: [
                   const Icon(Icons.local_offer, color: Colors.white, size: 24),
-                  const SizedBox(width: 12),
-                  const Expanded(
+                  SizedBox(width: spacingMD(context)),
+                  Expanded(
                     child: Text(
                       'Add Discount',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
-                      ),
+                      style: titleMedium(context).copyWith(color: Colors.white),
                     ),
                   ),
                   IconButton(
@@ -373,7 +617,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
             // Content
             Flexible(
               child: SingleChildScrollView(
-                padding: const EdgeInsets.all(20),
+                padding: cardPadding(context),
                 child: Form(
                   key: _formKey,
                   child: Column(
@@ -388,37 +632,51 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                           prefixIcon: Icon(Icons.category),
                         ),
                         items: const [
-                          DropdownMenuItem(value: 'percentage', child: Text('Percentage Discount')),
-                          DropdownMenuItem(value: 'fixed_amount', child: Text('Fixed Amount Discount')),
-                          DropdownMenuItem(value: 'voucher', child: Text('Voucher Code')),
+                          DropdownMenuItem(
+                              value: 'percentage',
+                              child: Text('Percentage Discount')),
+                          DropdownMenuItem(
+                              value: 'fixed_amount',
+                              child: Text('Fixed Amount Discount')),
+                          DropdownMenuItem(
+                              value: 'voucher', child: Text('Voucher Code')),
                         ],
                         onChanged: (value) => setState(() => _type = value!),
                       ),
 
-                      const SizedBox(height: 16),
+                      SizedBox(height: spacingLG(context)),
 
                       // Value Input
                       TextFormField(
                         controller: _valueController,
                         decoration: InputDecoration(
-                          labelText: _type == 'percentage' ? 'Percentage (%)' : 'Amount (\$)',
+                          labelText: _type == 'percentage'
+                              ? 'Percentage (%)'
+                              : 'Amount (\$)',
                           border: const OutlineInputBorder(),
-                          prefixIcon: Icon(_type == 'percentage' ? Icons.percent : Icons.attach_money),
+                          prefixIcon: Icon(_type == 'percentage'
+                              ? Icons.percent
+                              : Icons.attach_money),
                           suffixText: _type == 'percentage' ? '%' : null,
                           prefixText: _type == 'fixed_amount' ? '\$ ' : null,
                         ),
-                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                        keyboardType: const TextInputType.numberWithOptions(
+                            decimal: true),
                         autofocus: true,
                         validator: (value) {
                           if (value == null || value.isEmpty) return 'Required';
                           final num = double.tryParse(value);
-                          if (num == null || num <= 0) return 'Enter valid positive number';
-                          if (_type == 'percentage' && num > 100) return 'Cannot exceed 100%';
+                          if (num == null || num <= 0) {
+                            return 'Enter valid positive number';
+                          }
+                          if (_type == 'percentage' && num > 100) {
+                            return 'Cannot exceed 100%';
+                          }
                           return null;
                         },
                       ),
 
-                      const SizedBox(height: 16),
+                      SizedBox(height: spacingLG(context)),
 
                       // Description
                       TextFormField(
@@ -433,7 +691,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
 
                       // Voucher Code (conditional)
                       if (_type == 'voucher') ...[
-                        const SizedBox(height: 16),
+                        SizedBox(height: spacingLG(context)),
                         TextFormField(
                           controller: _codeController,
                           decoration: const InputDecoration(
@@ -442,11 +700,13 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                             prefixIcon: Icon(Icons.confirmation_number),
                           ),
                           textCapitalization: TextCapitalization.characters,
-                          validator: (value) => value == null || value.isEmpty ? 'Code required for vouchers' : null,
+                          validator: (value) => value == null || value.isEmpty
+                              ? 'Code required for vouchers'
+                              : null,
                         ),
                       ],
 
-                      const SizedBox(height: 20),
+                      SizedBox(height: spacingXL(context)),
 
                       // Options
                       Card(
@@ -456,27 +716,34 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                           children: [
                             SwitchListTile(
                               title: const Text('Apply to Add-ons'),
-                              subtitle: const Text('Include add-on products in discount'),
+                              subtitle: const Text(
+                                  'Include add-on products in discount'),
                               value: _applyToAddons,
-                              onChanged: (value) => setState(() => _applyToAddons = value),
+                              onChanged: (value) =>
+                                  setState(() => _applyToAddons = value),
                             ),
                             ListTile(
                               leading: const Icon(Icons.calendar_today),
                               title: const Text('Expiry Date'),
                               subtitle: Text(
                                 _expiryDate != null
-                                    ? DateFormat('MMM dd, yyyy').format(_expiryDate!)
+                                    ? DateFormat('MMM dd, yyyy')
+                                        .format(_expiryDate!)
                                     : 'No expiry date set',
                               ),
                               trailing: const Icon(Icons.chevron_right),
                               onTap: () async {
                                 final date = await showDatePicker(
                                   context: context,
-                                  initialDate: DateTime.now().add(const Duration(days: 30)),
+                                  initialDate: DateTime.now()
+                                      .add(const Duration(days: 30)),
                                   firstDate: DateTime.now(),
-                                  lastDate: DateTime.now().add(const Duration(days: 365)),
+                                  lastDate: DateTime.now()
+                                      .add(const Duration(days: 365)),
                                 );
-                                if (date != null) setState(() => _expiryDate = date);
+                                if (date != null) {
+                                  setState(() => _expiryDate = date);
+                                }
                               },
                             ),
                           ],
@@ -490,7 +757,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
 
             // Action Buttons
             Container(
-              padding: const EdgeInsets.all(20),
+              padding: cardPadding(context),
               decoration: BoxDecoration(
                 color: Colors.grey[50],
                 borderRadius: const BorderRadius.only(
@@ -504,12 +771,13 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                     child: OutlinedButton(
                       onPressed: () => Navigator.pop(context),
                       style: OutlinedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        padding:
+                            EdgeInsets.symmetric(vertical: spacingLG(context)),
                       ),
                       child: const Text('Cancel'),
                     ),
                   ),
-                  const SizedBox(width: 12),
+                  SizedBox(width: spacingMD(context)),
                   Expanded(
                     flex: 2,
                     child: ElevatedButton(
@@ -517,7 +785,8 @@ class _DiscountDialogState extends State<_DiscountDialog> {
                       style: ElevatedButton.styleFrom(
                         backgroundColor: RufkoTheme.primaryColor,
                         foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        padding:
+                            EdgeInsets.symmetric(vertical: spacingLG(context)),
                       ),
                       child: const Text('Add Discount'),
                     ),
@@ -530,6 +799,7 @@ class _DiscountDialogState extends State<_DiscountDialog> {
       ),
     );
   }
+
   void _addDiscount() {
     if (!_formKey.currentState!.validate()) return;
 
@@ -537,7 +807,9 @@ class _DiscountDialogState extends State<_DiscountDialog> {
       type: _type,
       value: double.parse(_valueController.text),
       code: _codeController.text.isEmpty ? null : _codeController.text,
-      description: _descriptionController.text.isEmpty ? null : _descriptionController.text,
+      description: _descriptionController.text.isEmpty
+          ? null
+          : _descriptionController.text,
       applyToAddons: _applyToAddons,
       expiryDate: _expiryDate,
     );

--- a/lib/widgets/adaptive_action_button.dart
+++ b/lib/widgets/adaptive_action_button.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../mixins/responsive_breakpoints_mixin.dart';
+import '../mixins/responsive_dimensions_mixin.dart';
+import '../mixins/responsive_spacing_mixin.dart';
+import '../mixins/responsive_text_mixin.dart';
+import '../mixins/responsive_widget_mixin.dart';
+import '../mixins/responsive_layout_mixin.dart';
+
+class AdaptiveActionButton extends StatelessWidget
+    with
+        ResponsiveBreakpointsMixin,
+        ResponsiveDimensionsMixin,
+        ResponsiveSpacingMixin,
+        ResponsiveTextMixin,
+        ResponsiveWidgetMixin,
+        ResponsiveLayoutMixin {
+  final VoidCallback onPressed;
+  final Widget icon;
+  final String label;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+
+  const AdaptiveActionButton({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+    required this.label,
+    this.backgroundColor,
+    this.foregroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: icon,
+      label: Text(label),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: backgroundColor,
+        foregroundColor: foregroundColor,
+        padding: EdgeInsets.symmetric(vertical: spacingLG(context)),
+      ),
+    );
+  }
+}

--- a/lib/widgets/adaptive_quote_card.dart
+++ b/lib/widgets/adaptive_quote_card.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../mixins/responsive_breakpoints_mixin.dart';
+import '../mixins/responsive_dimensions_mixin.dart';
+import '../mixins/responsive_spacing_mixin.dart';
+import '../mixins/responsive_text_mixin.dart';
+import '../mixins/responsive_widget_mixin.dart';
+import '../mixins/responsive_layout_mixin.dart';
+
+class AdaptiveQuoteCard extends StatelessWidget
+    with
+        ResponsiveBreakpointsMixin,
+        ResponsiveDimensionsMixin,
+        ResponsiveSpacingMixin,
+        ResponsiveTextMixin,
+        ResponsiveWidgetMixin,
+        ResponsiveLayoutMixin {
+  final Widget child;
+  final EdgeInsets? padding;
+  const AdaptiveQuoteCard({super.key, required this.child, this.padding});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: padding ?? cardPadding(context),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/widgets/responsive_level_grid.dart
+++ b/lib/widgets/responsive_level_grid.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../mixins/responsive_breakpoints_mixin.dart';
+import '../mixins/responsive_dimensions_mixin.dart';
+import '../mixins/responsive_spacing_mixin.dart';
+import '../mixins/responsive_text_mixin.dart';
+import '../mixins/responsive_widget_mixin.dart';
+import '../mixins/responsive_layout_mixin.dart';
+
+class ResponsiveLevelGrid extends StatelessWidget
+    with
+        ResponsiveBreakpointsMixin,
+        ResponsiveDimensionsMixin,
+        ResponsiveSpacingMixin,
+        ResponsiveTextMixin,
+        ResponsiveWidgetMixin,
+        ResponsiveLayoutMixin {
+  final List<Widget> children;
+  final int? columns;
+  const ResponsiveLevelGrid({super.key, required this.children, this.columns});
+
+  @override
+  Widget build(BuildContext context) {
+    final int crossAxisCount = columns ?? getGridColumns(context, xs: 1, sm: 2, md: 3, lg: 4, xl: 4);
+    return GridView.count(
+      crossAxisCount: crossAxisCount,
+      mainAxisSpacing: spacingSM(context),
+      crossAxisSpacing: spacingSM(context),
+      childAspectRatio: 3,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      children: children,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add adaptive widgets for actions, quote cards and grids
- refactor simplified quote detail screen with responsive layouts
- ensure visual density uses responsive values

## Testing
- `flutter analyze lib/widgets/adaptive_quote_card.dart lib/widgets/adaptive_action_button.dart lib/widgets/responsive_level_grid.dart --no-pub`
- `flutter analyze lib/screens/simplified_quote_detail_screen.dart --no-pub`
- `flutter test --reporter expanded`

------
https://chatgpt.com/codex/tasks/task_e_6849f47d3500832cb30d573e5e2b639c