### PR TITLE
Refactor template editor

### DIFF
--- a/lib/screens/template_editor_screen.dart
+++ b/lib/screens/template_editor_screen.dart
@@ -13,6 +13,9 @@ import '../models/field_definition.dart';
 import '../providers/app_state_provider.dart';
 import 'pdf_preview_screen.dart';
 import '../theme/rufko_theme.dart';
+import "../services/template_management_service.dart";
+import "../services/pdf_field_mapping_service.dart";
+import "../services/pdf_interaction_service.dart";
 
 class TemplateEditorScreen extends StatefulWidget {
   const TemplateEditorScreen({
@@ -337,30 +340,11 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
       return;
     }
 
-    final int tappedPageIndexZeroBased = details.pageNumber - 1;
-    final Offset tapInPdfPageCoords = details.pagePosition;
-
-    Map<String, dynamic>? tappedFieldInfo;
-
-    // Find which PDF field was tapped
-    for (final fieldInfo in _detectedPdfFieldsList) {
-      if ((fieldInfo['page'] as int? ?? -1) != tappedPageIndexZeroBased) continue;
-
-      final List<dynamic>? pdfRectValues = fieldInfo['rect'] as List<dynamic>?;
-      if (pdfRectValues == null || pdfRectValues.length != 4) continue;
-
-      final Rect fieldPdfBounds = Rect.fromLTWH(
-        (pdfRectValues[0] as num).toDouble(),
-        (pdfRectValues[1] as num).toDouble(),
-        (pdfRectValues[2] as num).toDouble(),
-        (pdfRectValues[3] as num).toDouble(),
-      );
-
-      if (fieldPdfBounds.contains(tapInPdfPageCoords)) {
-        tappedFieldInfo = fieldInfo;
-        break;
-      }
-    }
+    final tappedFieldInfo = PdfInteractionService.instance.getTappedField(
+      _detectedPdfFieldsList,
+      details.pageNumber - 1,
+      details.pagePosition,
+    );
 
     if (tappedFieldInfo != null) {
       _showFieldMappingDialog(tappedFieldInfo);
@@ -717,46 +701,21 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   }
 
   void _performMapping(String appDataType, Map<String, dynamic> pdfFieldInfo) {
-    final String pdfFieldName = pdfFieldInfo['name'] as String;
+    if (_currentTemplate == null) return;
 
-    if (kDebugMode) debugPrint("Creating mapping: $appDataType → $pdfFieldName");
+    PdfFieldMappingService.instance
+        .performMapping(_currentTemplate!, appDataType, pdfFieldInfo);
 
-    // Remove any existing mapping for this app data type
-    _currentTemplate!.fieldMappings.removeWhere((m) => m.appDataType == appDataType);
-
-    // Remove any existing mapping for this PDF field (including unmapped placeholders)
-    _currentTemplate!.fieldMappings.removeWhere((m) => m.pdfFormFieldName == pdfFieldName);
-
-    // Create new mapping (without override functionality)
-    final newMapping = FieldMapping(
-      appDataType: appDataType,
-      pdfFormFieldName: pdfFieldName,
-      detectedPdfFieldType: PdfFormFieldType.values.firstWhere(
-            (e) => e.toString() == pdfFieldInfo['type'],
-        orElse: () => PdfFormFieldType.unknown,
-      ),
-      pageNumber: pdfFieldInfo['page'] as int,
-    );
-
-    final relRect = pdfFieldInfo['relativeRect'] as List<dynamic>?;
-    if (relRect != null && relRect.length == 4) {
-      newMapping.visualX = relRect[0] as double?;
-      newMapping.visualY = relRect[1] as double?;
-      newMapping.visualWidth = relRect[2] as double?;
-      newMapping.visualHeight = relRect[3] as double?;
-    }
-
-    _currentTemplate!.addField(newMapping);
     _currentTemplate!.updatedAt = DateTime.now();
-    debugPrint('🔧 Saving template with category: $_selectedCategoryKey');
-    _currentTemplate!.userCategoryKey = _selectedCategoryKey; // Save selected category
-    debugPrint('🔧 Template userCategoryKey after save: ${_currentTemplate!.userCategoryKey}');
+    _currentTemplate!.userCategoryKey = _selectedCategoryKey;
 
     if (mounted) {
-      setState(() {}); // Refresh UI
+      setState(() {});
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Linked "${PDFTemplate.getFieldDisplayName(appDataType)}" to "$pdfFieldName"'),
+          content: Text(
+            'Linked "${PDFTemplate.getFieldDisplayName(appDataType)}" to "${pdfFieldInfo['name']}"',
+          ),
           backgroundColor: Colors.green,
         ),
       );
@@ -764,21 +723,15 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
   }
 
   void _unlinkField(FieldMapping mapping) {
-    if (!mounted) return;
+    if (!mounted || _currentTemplate == null) return;
 
-    setState(() {
-      mapping.pdfFormFieldName = '';
-      mapping.detectedPdfFieldType = PdfFormFieldType.unknown;
-      mapping.visualX = null;
-      mapping.visualY = null;
-      mapping.visualWidth = null;
-      mapping.visualHeight = null;
-      _currentTemplate!.updateField(mapping);
-    });
+    PdfFieldMappingService.instance.unlinkField(_currentTemplate!, mapping);
+
+    setState(() {});
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
-        content: Text("Field mapping removed."),
+        content: Text('Field mapping removed.'),
         backgroundColor: Colors.orange,
       ),
     );
@@ -818,19 +771,19 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
         final filePath = result.files.single.path!;
         final originalFileName = result.files.single.name;
 
-        final templateName = await _showTemplateNameDialog(originalFileName.replaceAll('.pdf', ''));
+        final templateName =
+            await _showTemplateNameDialog(originalFileName.replaceAll('.pdf', ''));
         if (templateName == null || templateName.trim().isEmpty) {
           _setLoading(false);
           return;
         }
 
-        final template =
-            await appState.createPDFTemplateFromFile(filePath, templateName.trim());
+        final template = await TemplateManagementService.instance
+            .uploadAndCreateTemplate(filePath, templateName.trim(), appState);
         _setLoading(false);
 
         if (!mounted) return;
         if (template != null) {
-
           setState(() {
             _currentTemplate = template;
             _loadTemplateDetails();
@@ -861,7 +814,7 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
           backgroundColor: Colors.red,
         ),
       );
-      if (kDebugMode) debugPrint("Error uploading/creating template: $e");
+      if (kDebugMode) debugPrint('Error uploading/creating template: $e');
     }
   }
 
@@ -882,9 +835,9 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
     final navigator = Navigator.of(context);
     final appState = context.read<AppStateProvider>();
     try {
-      _currentTemplate!.updatedAt = DateTime.now();
       _currentTemplate!.userCategoryKey = _selectedCategoryKey;
-      await appState.updatePDFTemplate(_currentTemplate!);
+      await TemplateManagementService.instance
+          .saveTemplate(_currentTemplate!, appState);
 
       if (!mounted) return;
       messenger.showSnackBar(
@@ -913,8 +866,8 @@ class _TemplateEditorScreenState extends State<TemplateEditorScreen> {
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
     try {
-      final previewPath =
-          await appState.generateTemplatePreview(_currentTemplate!);
+      final previewPath = await TemplateManagementService.instance
+          .generateTemplatePreview(_currentTemplate!, appState);
       _setLoading(false);
 
       if (!mounted) return;

--- a/lib/services/pdf_field_mapping_service.dart
+++ b/lib/services/pdf_field_mapping_service.dart
@@ -3,6 +3,7 @@
 import 'package:intl/intl.dart';
 import '../models/customer.dart';
 import '../models/simplified_quote.dart';
+import "../models/pdf_template.dart";
 import '../providers/app_state_provider.dart';
 
 /// Handles mapping of PDF template fields to display names and values.
@@ -101,5 +102,49 @@ class PdfFieldMappingService {
         .where((m) => m.pdfFormFieldName.isNotEmpty)
         .map((m) => m.appDataType)
         .toList();
+  }
+
+  /// Link [appDataType] to a PDF field described by [pdfFieldInfo] on [template].
+  void performMapping(
+    PDFTemplate template,
+    String appDataType,
+    Map<String, dynamic> pdfFieldInfo,
+  ) {
+    final pdfFieldName = pdfFieldInfo['name'] as String;
+
+    template.fieldMappings.removeWhere((m) => m.appDataType == appDataType);
+    template.fieldMappings.removeWhere((m) => m.pdfFormFieldName == pdfFieldName);
+
+    final mapping = FieldMapping(
+      appDataType: appDataType,
+      pdfFormFieldName: pdfFieldName,
+      detectedPdfFieldType: PdfFormFieldType.values.firstWhere(
+        (e) => e.toString() == pdfFieldInfo['type'],
+        orElse: () => PdfFormFieldType.unknown,
+      ),
+      pageNumber: pdfFieldInfo['page'] as int,
+    );
+
+    final relRect = pdfFieldInfo['relativeRect'] as List<dynamic>?;
+    if (relRect != null && relRect.length == 4) {
+      mapping.visualX = relRect[0] as double?;
+      mapping.visualY = relRect[1] as double?;
+      mapping.visualWidth = relRect[2] as double?;
+      mapping.visualHeight = relRect[3] as double?;
+    }
+
+    template.addField(mapping);
+  }
+
+  /// Remove the mapping information for [mapping] on [template].
+  void unlinkField(PDFTemplate template, FieldMapping mapping) {
+    mapping
+      ..pdfFormFieldName = ''
+      ..detectedPdfFieldType = PdfFormFieldType.unknown
+      ..visualX = null
+      ..visualY = null
+      ..visualWidth = null
+      ..visualHeight = null;
+    template.updateField(mapping);
   }
 }

--- a/lib/services/pdf_interaction_service.dart
+++ b/lib/services/pdf_interaction_service.dart
@@ -1,0 +1,43 @@
+// lib/services/pdf_interaction_service.dart
+
+import 'dart:ui';
+import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
+
+class PdfInteractionService {
+  PdfInteractionService._internal();
+  static final PdfInteractionService instance = PdfInteractionService._internal();
+
+  /// Determine which detected PDF field was tapped, if any.
+  Map<String, dynamic>? getTappedField(
+    List<Map<String, dynamic>> detectedFields,
+    int pageIndex,
+    Offset tapPosition,
+  ) {
+    for (final field in detectedFields) {
+      if ((field['page'] as int? ?? -1) != pageIndex) continue;
+      final rectValues = field['rect'] as List<dynamic>?;
+      if (rectValues == null || rectValues.length != 4) continue;
+      final rect = Rect.fromLTWH(
+        (rectValues[0] as num).toDouble(),
+        (rectValues[1] as num).toDouble(),
+        (rectValues[2] as num).toDouble(),
+        (rectValues[3] as num).toDouble(),
+      );
+      if (rect.contains(tapPosition)) return field;
+    }
+    return null;
+  }
+
+  /// Keep [_currentPage] in sync with [controller] page changes.
+  void attachPageListener(
+    PdfViewerController controller,
+    void Function(int pageIndex) onPageChanged,
+  ) {
+    controller.addListener(() {
+      final page = controller.pageNumber;
+      if (page > 0) {
+        onPageChanged(page - 1);
+      }
+    });
+  }
+}

--- a/lib/services/template_management_service.dart
+++ b/lib/services/template_management_service.dart
@@ -1,0 +1,65 @@
+// lib/services/template_management_service.dart
+
+import 'package:flutter/foundation.dart';
+
+import '../models/pdf_template.dart';
+import '../providers/app_state_provider.dart';
+import '../utils/template_validator.dart';
+
+class TemplateManagementService {
+  TemplateManagementService._internal();
+  static final TemplateManagementService instance =
+      TemplateManagementService._internal();
+
+  /// Create a [PDFTemplate] from a picked PDF file path and template name.
+  Future<PDFTemplate?> uploadAndCreateTemplate(
+    String pdfPath,
+    String templateName,
+    AppStateProvider appState,
+  ) async {
+    try {
+      return await appState.createPDFTemplateFromFile(pdfPath, templateName);
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('TemplateManagementService upload error: $e');
+      }
+      rethrow;
+    }
+  }
+
+  /// Persist updates to a [PDFTemplate].
+  Future<void> saveTemplate(
+    PDFTemplate template,
+    AppStateProvider appState,
+  ) async {
+    try {
+      template.updatedAt = DateTime.now();
+      await appState.updatePDFTemplate(template);
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('TemplateManagementService save error: $e');
+      }
+      rethrow;
+    }
+  }
+
+  /// Generate a populated preview PDF for [template].
+  Future<String> generateTemplatePreview(
+    PDFTemplate template,
+    AppStateProvider appState,
+  ) async {
+    try {
+      return await appState.generateTemplatePreview(template);
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('TemplateManagementService preview error: $e');
+      }
+      rethrow;
+    }
+  }
+
+  /// Validate [template] and return the [TemplateValidationResult].
+  Future<TemplateValidationResult> validateTemplate(PDFTemplate template) async {
+    return TemplateValidator.validateTemplate(template);
+  }
+}


### PR DESCRIPTION
## Summary
- extract template management logic to `TemplateManagementService`
- extract PDF interaction helpers to `PdfInteractionService`
- extend `PdfFieldMappingService` with mapping helpers
- use services in `TemplateEditorScreen`

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684a0f3021ec832ca942fd5f32b5b0c5