### PR TITLE
Fix field dialog default category

### DIFF
--- a/lib/widgets/templates/dialgos/field_dialog.dart
+++ b/lib/widgets/templates/dialgos/field_dialog.dart
@@ -312,7 +312,9 @@ class _FieldDialogState extends State<FieldDialog> with FieldTypeMixin {
       } else if (_currentCategories.isNotEmpty) {
         _selectedFieldCategory = _currentCategories.first;
       } else {
-        _selectedFieldCategory = '';
+        // When no categories exist yet, default to the special
+        // "Create New Category" option so the dropdown has a valid value.
+        _selectedFieldCategory = _createNewCategoryValue;
       }
       _selectedFieldType = 'text';
       _isRequired = false;


### PR DESCRIPTION
## Summary
- ensure FieldDialog shows category dropdown when no categories exist

## Testing
- `dart analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684a3052b938832c8df392552013b98c