### PR TITLE
Restore category creation in template dialog

### DIFF
--- a/lib/widgets/templates/dialgos/category_creation_dialog.dart
+++ b/lib/widgets/templates/dialgos/category_creation_dialog.dart
@@ -12,6 +12,18 @@ class _CategoryCreationDialogState extends State<CategoryCreationDialog> {
   final TextEditingController controller = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Dialog(
       child: Padding(
@@ -35,8 +47,8 @@ class _CategoryCreationDialogState extends State<CategoryCreationDialog> {
                   child: const Text('Cancel'),
                 ),
                 ElevatedButton(
-                  onPressed: controller.text.isNotEmpty
-                      ? () => Navigator.of(context).pop(controller.text)
+                  onPressed: controller.text.trim().isNotEmpty
+                      ? () => Navigator.of(context).pop(controller.text.trim())
                       : null,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: RufkoTheme.primaryColor,

--- a/lib/widgets/templates/dialgos/category_selection_dialog.dart
+++ b/lib/widgets/templates/dialgos/category_selection_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../providers/app_state_provider.dart';
 import '../../../theme/rufko_theme.dart';
+import 'category_creation_dialog.dart';
 
 class CategorySelectionDialog extends StatefulWidget {
   const CategorySelectionDialog({super.key});
@@ -25,6 +26,25 @@ class _CategorySelectionDialogState extends State<CategorySelectionDialog> {
         c.key: c.name,
     };
     if (categories.isNotEmpty) selectedCategory = categories.keys.first;
+  }
+
+  Future<void> _addCategory() async {
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (_) => const CategoryCreationDialog(),
+    );
+    if (newName != null && newName.trim().isNotEmpty && mounted) {
+      final appState = context.read<AppStateProvider>();
+      final key = newName
+          .toLowerCase()
+          .replaceAll(RegExp(r'[^\w\s]'), '')
+          .replaceAll(' ', '_');
+      await appState.addTemplateCategory('pdf_templates', key, newName.trim());
+      setState(() {
+        categories[key] = newName.trim();
+        selectedCategory = key;
+      });
+    }
   }
 
   @override
@@ -67,6 +87,12 @@ class _CategorySelectionDialogState extends State<CategorySelectionDialog> {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
+              TextButton.icon(
+                onPressed: _addCategory,
+                icon: const Icon(Icons.add),
+                label: const Text('New Category'),
+              ),
+              const Spacer(),
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
                 child: const Text('Cancel'),


### PR DESCRIPTION
## Summary
- allow creating new template categories directly from the selector
- enable the Create button in the category creation dialog by updating its state

## Testing
- `./setup.sh`
- `~/flutter/bin/flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_684a3d352f98832cb9d0d1c105a617e6